### PR TITLE
revise: supports full set of subject fields in group by count

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -422,6 +422,7 @@ dependencies = [
  "ccdi-cde",
  "ccdi-models",
  "indexmap 2.0.2",
+ "log",
  "mime",
  "rand",
  "serde",

--- a/packages/Cargo.toml
+++ b/packages/Cargo.toml
@@ -15,6 +15,7 @@ edition = "2021"
 [workspace.dependencies]
 actix-web = "4.4.0"
 indexmap = "2.0.2"
+log = "0.4.20"
 mime = "0.3.17"
 rand = "0.8.5"
 serde = { version = "1.0.189", features = ["serde_derive"] }

--- a/packages/ccdi-server/Cargo.toml
+++ b/packages/ccdi-server/Cargo.toml
@@ -9,6 +9,7 @@ actix-web.workspace = true
 ccdi-cde = { path = "../ccdi-cde", version = "0.1.0" }
 ccdi-models = { path = "../ccdi-models", version = "0.1.0" }
 indexmap.workspace = true
+log.workspace = true
 mime.workspace = true
 rand.workspace = true
 serde.workspace = true

--- a/packages/ccdi-spec/Cargo.toml
+++ b/packages/ccdi-spec/Cargo.toml
@@ -10,6 +10,6 @@ env_logger = "0.10.0"
 ccdi-openapi = { path = "../ccdi-openapi", version = "0.1.0" }
 ccdi-server = { path = "../ccdi-server", version = "0.1.0" }
 clap = { version = "4.4.6", features = ["derive"] }
-log = "0.4.20"
+log.workspace = true
 utoipa.workspace = true
 utoipa-swagger-ui.workspace = true


### PR DESCRIPTION
This PR adds grouping by `ethnicity` and `identifiers`, effectively implementing group by and count for all subject metadata fields.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
