### PR TITLE
fix typo in server description

### DIFF
--- a/packages/ccdi-openapi/src/api.rs
+++ b/packages/ccdi-openapi/src/api.rs
@@ -36,11 +36,11 @@ a variety of query parameters.",
         ),
         (
             url = "https://ccdifederation.pedscommons.org/api/v0",
-            description = "UCSC Treehouse CCDI API server"
+            description = "Pediatric Cancer Data Commons CCDI API server"
         ),
         (
             url = "https://ccdi.treehouse.gi.ucsc.edu/api/v0",
-            description = "Pediatric Cancer Data Commons CCDI API server"
+            description = "UCSC Treehouse CCDI API server"
         ),
     ),
     tags(

--- a/swagger.yml
+++ b/swagger.yml
@@ -14,9 +14,9 @@ servers:
 - url: https://ccdi.stjude.cloud/api/v0
   description: St. Jude Children's Research Hospital CCDI API server
 - url: https://ccdifederation.pedscommons.org/api/v0
-  description: UCSC Treehouse CCDI API server
-- url: https://ccdi.treehouse.gi.ucsc.edu/api/v0
   description: Pediatric Cancer Data Commons CCDI API server
+- url: https://ccdi.treehouse.gi.ucsc.edu/api/v0
+  description: UCSC Treehouse CCDI API server
 paths:
   /metadata/fields/subject:
     get:


### PR DESCRIPTION
The description of the Treehouse server and the PCDC have been inverted.

Before submitting this PR, please make sure:

- [X ] You have added a few sentences describing the PR here.
- [X ] You have added yourself or the appropriate individual as the assignee.
- [X ] You have added the relevant groups/individuals to the reviewers.
- [ ] Your commit messages conform to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
