### PR TITLE
feat: adds filtering via query params for `/sample` and `/subject`

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -447,6 +447,7 @@ dependencies = [
  "ccdi-cde",
  "ccdi-models",
  "indexmap 2.0.2",
+ "introspect",
  "itertools",
  "log",
  "mime",

--- a/packages/ccdi-models/src/lib.rs
+++ b/packages/ccdi-models/src/lib.rs
@@ -10,6 +10,9 @@
 #![feature(decl_macro)]
 #![feature(trivial_bounds)]
 
+/// A marker trait for queriable entities within this API.
+pub trait Entity {}
+
 pub mod metadata;
 pub mod sample;
 pub mod subject;

--- a/packages/ccdi-models/src/metadata/field/owned.rs
+++ b/packages/ccdi-models/src/metadata/field/owned.rs
@@ -176,6 +176,12 @@ macro_rules! owned_field {
                 $name::new(rand::random(), None, None, Some(false))
             }
         }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.value)
+            }
+        }
     };
 }
 

--- a/packages/ccdi-models/src/metadata/field/unowned.rs
+++ b/packages/ccdi-models/src/metadata/field/unowned.rs
@@ -142,6 +142,12 @@ macro_rules! unowned_field {
                 $name::new(rand::random(), None, None)
             }
         }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.value)
+            }
+        }
     };
 }
 

--- a/packages/ccdi-models/src/sample.rs
+++ b/packages/ccdi-models/src/sample.rs
@@ -12,6 +12,8 @@ pub mod metadata;
 pub use identifier::Identifier;
 pub use metadata::Metadata;
 
+use crate::Entity;
+
 /// A sample.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema)]
 #[schema(as = models::Sample)]
@@ -127,6 +129,8 @@ impl Sample {
         }
     }
 }
+
+impl Entity for Sample {}
 
 impl PartialOrd for Sample {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {

--- a/packages/ccdi-models/src/sample/metadata.rs
+++ b/packages/ccdi-models/src/sample/metadata.rs
@@ -56,15 +56,15 @@ impl Metadata {
     ///
     /// assert_eq!(
     ///     metadata.disease_phase(),
-    ///     &Some(DiseasePhase::new(
+    ///     Some(&DiseasePhase::new(
     ///         cde::v1::sample::DiseasePhase::InitialDiagnosis,
     ///         None,
     ///         None
     ///     ))
     /// );
     /// ```
-    pub fn disease_phase(&self) -> &Option<field::unowned::sample::DiseasePhase> {
-        &self.disease_phase
+    pub fn disease_phase(&self) -> Option<&field::unowned::sample::DiseasePhase> {
+        self.disease_phase.as_ref()
     }
 
     /// Gets the harmonized tissue type for the [`Metadata`].
@@ -88,15 +88,15 @@ impl Metadata {
     ///
     /// assert_eq!(
     ///     metadata.tissue_type(),
-    ///     &Some(TissueType::new(
+    ///     Some(&TissueType::new(
     ///         cde::v2::sample::TissueType::Tumor,
     ///         None,
     ///         None
     ///     ))
     /// );
     /// ```
-    pub fn tissue_type(&self) -> &Option<field::unowned::sample::TissueType> {
-        &self.tissue_type
+    pub fn tissue_type(&self) -> Option<&field::unowned::sample::TissueType> {
+        self.tissue_type.as_ref()
     }
 
     /// Gets the harmonized tumor classification for the [`Metadata`].
@@ -120,15 +120,15 @@ impl Metadata {
     ///
     /// assert_eq!(
     ///     metadata.tumor_classification(),
-    ///     &Some(TumorClassification::new(
+    ///     Some(&TumorClassification::new(
     ///         cde::v1::sample::TumorClassification::Primary,
     ///         None,
     ///         None
     ///     ))
     /// );
     /// ```
-    pub fn tumor_classification(&self) -> &Option<field::unowned::sample::TumorClassification> {
-        &self.tumor_classification
+    pub fn tumor_classification(&self) -> Option<&field::unowned::sample::TumorClassification> {
+        self.tumor_classification.as_ref()
     }
 
     /// Gets the unharmonized fields for the [`Metadata`].

--- a/packages/ccdi-models/src/subject.rs
+++ b/packages/ccdi-models/src/subject.rs
@@ -16,6 +16,8 @@ pub mod metadata;
 pub use kind::Kind;
 pub use metadata::Metadata;
 
+use crate::Entity;
+
 /// A subject.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema)]
 #[schema(as = models::Subject)]
@@ -128,12 +130,12 @@ impl Subject {
     ///     Some(Builder::default().build()),
     /// );
     ///
-    /// assert_eq!(subject.name(), &String::from("Name"));
+    /// assert_eq!(subject.name(), "Name");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn name(&self) -> &String {
-        &self.name
+    pub fn name(&self) -> &str {
+        self.name.as_str()
     }
 
     /// Gets the kind for this [`Subject`] by reference.
@@ -212,7 +214,7 @@ impl Subject {
 
         Self {
             id: identifier.clone(),
-            name: identifier.name().clone(),
+            name: identifier.name().to_string(),
             kind: rand::random(),
             metadata: match rng.gen_bool(0.7) {
                 true => Some(Metadata::random(identifier)),
@@ -221,6 +223,8 @@ impl Subject {
         }
     }
 }
+
+impl Entity for Subject {}
 
 impl PartialOrd for Subject {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {

--- a/packages/ccdi-models/src/subject/metadata.rs
+++ b/packages/ccdi-models/src/subject/metadata.rs
@@ -60,11 +60,11 @@ impl Metadata {
     ///
     /// assert_eq!(
     ///     metadata.sex(),
-    ///     &Some(Sex::new(cde::v1::subject::Sex::Female, None, None))
+    ///     Some(&Sex::new(cde::v1::subject::Sex::Female, None, None))
     /// );
     /// ```
-    pub fn sex(&self) -> &Option<field::unowned::subject::Sex> {
-        &self.sex
+    pub fn sex(&self) -> Option<&field::unowned::subject::Sex> {
+        self.sex.as_ref()
     }
 
     /// Gets the harmonized race(s) for the [`Metadata`].
@@ -84,11 +84,11 @@ impl Metadata {
     ///
     /// assert_eq!(
     ///     metadata.race(),
-    ///     &Some(vec![Race::new(cde::v1::subject::Race::Asian, None, None)])
+    ///     Some(&vec![Race::new(cde::v1::subject::Race::Asian, None, None)])
     /// );
     /// ```
-    pub fn race(&self) -> &Option<Vec<field::unowned::subject::Race>> {
-        &self.race
+    pub fn race(&self) -> Option<&Vec<field::unowned::subject::Race>> {
+        self.race.as_ref()
     }
 
     /// Gets the harmonized ethnicity for the [`Metadata`].
@@ -112,15 +112,15 @@ impl Metadata {
     ///
     /// assert_eq!(
     ///     metadata.ethnicity(),
-    ///     &Some(Ethnicity::new(
+    ///     Some(&Ethnicity::new(
     ///         cde::v2::subject::Ethnicity::NotHispanicOrLatino,
     ///         None,
     ///         None
     ///     ))
     /// );
     /// ```
-    pub fn ethnicity(&self) -> &Option<field::unowned::subject::Ethnicity> {
-        &self.ethnicity
+    pub fn ethnicity(&self) -> Option<&field::unowned::subject::Ethnicity> {
+        self.ethnicity.as_ref()
     }
 
     /// Gets the harmonized identifier(s) for the [`Metadata`].
@@ -145,7 +145,7 @@ impl Metadata {
     ///
     /// assert_eq!(
     ///     metadata.identifiers(),
-    ///     &Some(vec![Identifier::new(
+    ///     Some(&vec![Identifier::new(
     ///         cde::v1::subject::Identifier::parse("organization:Name", ":").unwrap(),
     ///         None,
     ///         None,
@@ -153,8 +153,8 @@ impl Metadata {
     ///     )])
     /// );
     /// ```
-    pub fn identifiers(&self) -> &Option<Vec<field::owned::subject::Identifier>> {
-        &self.identifiers
+    pub fn identifiers(&self) -> Option<&Vec<field::owned::subject::Identifier>> {
+        self.identifiers.as_ref()
     }
 
     /// Gets the unharmonized fields for the [`Metadata`].

--- a/packages/ccdi-server/Cargo.toml
+++ b/packages/ccdi-server/Cargo.toml
@@ -10,6 +10,7 @@ ccdi-cde = { path = "../ccdi-cde" }
 ccdi-models = { path = "../ccdi-models" }
 indexmap.workspace = true
 itertools = "0.11.0"
+introspect.workspace = true
 log.workspace = true
 mime.workspace = true
 rand.workspace = true

--- a/packages/ccdi-server/src/filter.rs
+++ b/packages/ccdi-server/src/filter.rs
@@ -1,0 +1,150 @@
+//! Common filtering utilities.
+
+use introspect::Introspected;
+
+use ccdi_models as models;
+
+use models::Entity;
+
+pub mod sample;
+pub mod subject;
+
+/// A trait that defines a method for filtering by metadata values.
+///
+/// **Note:** can only be implemented for an API [`Entity`].
+pub trait FilterMetadataField<T, P>
+where
+    T: Entity,
+{
+    /// Filters entities by checking if the value of the provided field name
+    /// matches the value of that field within the filter parameters. Matches
+    /// are case-sensitive.
+    fn filter_metadata_field(self, field: String, filter_params: &P) -> Vec<T>;
+}
+
+/// Filters a list of entities based on the provided filter parameters.
+///
+/// # Examples
+///
+/// ```
+/// use ccdi_cde as cde;
+/// use ccdi_models as models;
+/// use ccdi_server as server;
+///
+/// use cde::v1::subject::Identifier;
+/// use models::metadata::field::unowned::subject::Race;
+/// use models::metadata::field::unowned::subject::Sex;
+/// use models::subject::metadata::Builder;
+/// use models::subject::Kind;
+/// use models::Subject;
+/// use server::filter::filter;
+/// use server::params::filter::Subject as SubjectFilterParams;
+///
+/// let subjects = vec![
+///     // A subject with no metadata.
+///     Subject::new(
+///         Identifier::new("organization", "SubjectName001"),
+///         String::from("SubjectName001"),
+///         Kind::Participant,
+///         Some(Builder::default().build()),
+///     ),
+///     // A subject with metadata but no specified sex.
+///     Subject::new(
+///         Identifier::new("organization", "SubjectName002"),
+///         String::from("SubjectName002"),
+///         Kind::Participant,
+///         Some(Builder::default().build()),
+///     ),
+///     // A subject with sex 'F'.
+///     Subject::new(
+///         Identifier::new("organization", "SubjectName003"),
+///         String::from("SubjectName003"),
+///         Kind::Participant,
+///         Some(
+///             Builder::default()
+///                 .sex(Sex::new(cde::v1::subject::Sex::Female, None, None))
+///                 .build(),
+///         ),
+///     ),
+///     // A subject with sex 'F' and race 'Asian'.
+///     Subject::new(
+///         Identifier::new("organization", "SubjectName004"),
+///         String::from("SubjectName004"),
+///         Kind::Participant,
+///         Some(
+///             Builder::default()
+///                 .sex(Sex::new(cde::v1::subject::Sex::Female, None, None))
+///                 .append_race(Race::new(cde::v1::subject::Race::Asian, None, None))
+///                 .build(),
+///         ),
+///     ),
+/// ];
+///
+/// // Filtering of subjects with no parameters.
+/// let mut results =
+///     filter::<Subject, SubjectFilterParams>(subjects.clone(), SubjectFilterParams::default());
+///
+/// assert_eq!(results.len(), 4);
+///
+/// // Filtering of subjects with "F" in sex field.
+/// let mut results = filter::<Subject, SubjectFilterParams>(
+///     subjects.clone(),
+///     SubjectFilterParams {
+///         sex: Some(String::from("F")),
+///         race: None,
+///         ethnicity: None,
+///         identifiers: None,
+///     },
+/// );
+///
+/// assert_eq!(results.len(), 2);
+/// assert_eq!(results.first().unwrap().name(), "SubjectName003");
+/// assert_eq!(results.last().unwrap().name(), "SubjectName004");
+///
+/// // Filtering of subjects with "F" in sex field and "Asi" in race field.
+/// let mut results = filter::<Subject, SubjectFilterParams>(
+///     subjects.clone(),
+///     SubjectFilterParams {
+///         sex: Some(String::from("F")),
+///         race: Some(String::from("Asian")),
+///         ethnicity: None,
+///         identifiers: None,
+///     },
+/// );
+///
+/// assert_eq!(results.len(), 1);
+/// assert_eq!(results.pop().unwrap().name(), "SubjectName004");
+///
+/// // Filtering of subjects is case-sensitive.
+/// let mut results = filter::<Subject, SubjectFilterParams>(
+///     subjects.clone(),
+///     SubjectFilterParams {
+///         sex: Some(String::from("f")),
+///         race: None,
+///         ethnicity: None,
+///         identifiers: None,
+///     },
+/// );
+///
+/// assert_eq!(results.len(), 0);
+/// ```
+pub fn filter<T, P>(mut entities: Vec<T>, filter_params: P) -> Vec<T>
+where
+    T: Entity,
+    Vec<T>: FilterMetadataField<T, P>,
+    P: Introspected,
+{
+    for member in P::introspected_members() {
+        let field = match member {
+            // SAFETY: parameters will _always_ be expression as a struct with
+            // named fields. If they are not, this method will not work.
+            introspect::Member::Field(field) => field.identifier().unwrap().to_string(),
+            // SAFETY: parameters will never be expressed as an `enum`.
+            introspect::Member::Variant(_) => unreachable!(),
+        };
+
+        entities = entities.filter_metadata_field(field, &filter_params);
+    }
+
+    entities
+}

--- a/packages/ccdi-server/src/filter/sample.rs
+++ b/packages/ccdi-server/src/filter/sample.rs
@@ -1,0 +1,53 @@
+//! Filter parameters for [`Sample`]s.
+
+use ccdi_models as models;
+
+use models::Sample;
+
+use crate::filter::FilterMetadataField;
+use crate::params::filter::Sample as FilterSampleParams;
+
+impl FilterMetadataField<Sample, FilterSampleParams> for Vec<Sample> {
+    fn filter_metadata_field(self, field: String, params: &FilterSampleParams) -> Vec<Sample> {
+        let parameter = match field.as_str() {
+            "disease_phase" => params.disease_phase.as_ref(),
+            "tissue_type" => params.tissue_type.as_ref(),
+            "tumor_classification" => params.tumor_classification.as_ref(),
+            _ => unreachable!("unhandled sample metadata field: {field}"),
+        };
+
+        let query = match parameter {
+            Some(query) => query,
+            // If the parameter has no value, just return the original list of
+            // samples, as the user does not want to filter based on that.
+            None => return self,
+        };
+
+        self.into_iter()
+            .filter(|sample| {
+                let values: Option<Vec<String>> = match field.as_str() {
+                    "disease_phase" => sample
+                        .metadata()
+                        .and_then(|metadata| metadata.disease_phase())
+                        .map(|disease_phase| vec![disease_phase.to_string()]),
+                    "tissue_type" => sample
+                        .metadata()
+                        .and_then(|metadata| metadata.tissue_type())
+                        .map(|tissue_type| vec![tissue_type.to_string()]),
+                    "tumor_classification" => sample
+                        .metadata()
+                        .and_then(|metadata| metadata.tumor_classification())
+                        .map(|tumor_classification| vec![tumor_classification.to_string()]),
+                    _ => unreachable!("unhandled sample metadata field: {field}"),
+                };
+
+                match values {
+                    Some(values) => values.into_iter().any(|s| s.eq(query)),
+                    // Samples with no values for this field are automatically
+                    // filtered as described in the rules for filtering.
+                    None => false,
+                }
+            })
+            .collect::<Vec<_>>()
+    }
+}

--- a/packages/ccdi-server/src/filter/subject.rs
+++ b/packages/ccdi-server/src/filter/subject.rs
@@ -1,0 +1,69 @@
+//! Filter parameters for [`Subject`]s.
+
+use ccdi_models as models;
+
+use models::Subject;
+
+use crate::filter::FilterMetadataField;
+use crate::params::filter::Subject as FilterSubjectParams;
+
+impl FilterMetadataField<Subject, FilterSubjectParams> for Vec<Subject> {
+    fn filter_metadata_field(self, field: String, params: &FilterSubjectParams) -> Vec<Subject> {
+        let parameter = match field.as_str() {
+            "sex" => params.sex.as_ref(),
+            "race" => params.race.as_ref(),
+            "ethnicity" => params.ethnicity.as_ref(),
+            "identifiers" => params.identifiers.as_ref(),
+            _ => unreachable!("unhandled subject metadata field: {field}"),
+        };
+
+        let query = match parameter {
+            Some(query) => query,
+            // If the parameter has no value, just return the original list of
+            // subjects, as the user does not want to filter based on that.
+            None => return self,
+        };
+
+        self.into_iter()
+            .filter(|subject| {
+                let values: Option<Vec<String>> = match field.as_str() {
+                    "sex" => subject
+                        .metadata()
+                        .and_then(|metadata| metadata.sex())
+                        .map(|sex| vec![sex.to_string()]),
+                    "race" => subject
+                        .metadata()
+                        .and_then(|metadata| metadata.race())
+                        .map(|race| {
+                            race.iter()
+                                .cloned()
+                                .map(|r| r.to_string())
+                                .collect::<Vec<String>>()
+                        }),
+                    "ethnicity" => subject
+                        .metadata()
+                        .and_then(|metadata| metadata.ethnicity())
+                        .map(|ethnicity| vec![ethnicity.to_string()]),
+                    "identifiers" => subject
+                        .metadata()
+                        .and_then(|metadata| metadata.identifiers())
+                        .map(|identifiers| {
+                            identifiers
+                                .iter()
+                                .cloned()
+                                .map(|r| r.to_string())
+                                .collect::<Vec<String>>()
+                        }),
+                    _ => unreachable!("unhandled subject metadata field: {field}"),
+                };
+
+                match values {
+                    Some(values) => values.into_iter().any(|s| s.eq(query)),
+                    // Subjects with no values for this field are automatically
+                    // filtered as described in the rules for filtering.
+                    None => false,
+                }
+            })
+            .collect::<Vec<_>>()
+    }
+}

--- a/packages/ccdi-server/src/lib.rs
+++ b/packages/ccdi-server/src/lib.rs
@@ -8,6 +8,7 @@
 #![warn(missing_debug_implementations)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
+pub mod filter;
 pub mod paginate;
 pub mod params;
 pub mod responses;

--- a/packages/ccdi-server/src/params.rs
+++ b/packages/ccdi-server/src/params.rs
@@ -1,5 +1,6 @@
 //! Common parameters used across the server.
 
+pub mod filter;
 pub mod pagination;
 
 pub use pagination::Pagination;

--- a/packages/ccdi-server/src/params/filter.rs
+++ b/packages/ccdi-server/src/params/filter.rs
@@ -1,0 +1,76 @@
+//! Parameters related to filtering.
+
+use introspect::Introspect;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::IntoParams;
+
+/// Parameters for filtering subjects.
+///
+/// None of the parameters are required, but they may be provided as a
+/// [`String`]. When a parameter is provided, the endpoint will filter the
+/// results to only include [`Subject`]s where the value for the key exactly
+/// matches the value provided for the parameter (i.e., matching is done by
+/// looking for the provided parameter as a substring). Matches are
+/// case-sensitive.
+#[derive(Debug, Default, Deserialize, IntoParams, Introspect, Serialize)]
+#[into_params(parameter_in = Query)]
+pub struct Subject {
+    /// Matches any subject where the `sex` field matches the string provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub sex: Option<String>,
+
+    /// Matches any subject where any member of the `race` fieldmatches
+    /// the string provided.
+    ///
+    /// **Note:** a logical OR (`||`) is performed across the values when
+    /// determining whether the subject should be included in the results.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub race: Option<String>,
+
+    /// matches any subject where the `ethnicity` field matches the string provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub ethnicity: Option<String>,
+
+    /// Matches any subject where any member of the `identifiers` fieldmatches
+    /// the string provided.
+    ///
+    /// **Note:** a logical OR (`||`) is performed across the values when
+    /// determining whether the subject should be included in the results.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub identifiers: Option<String>,
+}
+
+/// Parameters for filtering subjects.
+///
+/// None of the parameters are required, but they may be provided as a
+/// [`String`]. When a parameter is provided, the endpoint will filter the
+/// results to only include [`Subject`]s where the value for the key exactly
+/// matches the value provided for the parameter (i.e., matching is done by
+/// looking for the provided parameter as a substring). Matches are
+/// case-sensitive.
+#[derive(Debug, Default, Deserialize, IntoParams, Introspect, Serialize)]
+#[into_params(parameter_in = Query)]
+pub struct Sample {
+    /// Matches any subject where the `disease_phase` field matches the string
+    /// provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub disease_phase: Option<String>,
+
+    /// Matches any subject where the `tissue_type` field matches the string
+    /// provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub tissue_type: Option<String>,
+
+    /// Matches any subject where the `tumor_classification` field matches the
+    /// string provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub tumor_classification: Option<String>,
+}

--- a/packages/ccdi-server/src/params/pagination.rs
+++ b/packages/ccdi-server/src/params/pagination.rs
@@ -34,13 +34,9 @@ pub struct Pagination {
     /// **must** default to `1` when pagination is enabled but this parameter is
     /// not provided. Pagination is enabled if this parameter is provided to the
     /// endpoint.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "::serde_with::rust::double_option"
-    )]
-    #[param(nullable = false)]
-    page: Option<Option<usize>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    page: Option<usize>,
 
     /// The number of results per page.
     ///
@@ -48,13 +44,9 @@ pub struct Pagination {
     /// pagination is enabled but this parameter is not provided. A default
     /// value of `100` is recommended if all values are equally reasonable.
     /// Pagination is enabled if this parameter is provided to the endpoint.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "::serde_with::rust::double_option"
-    )]
-    #[param(nullable = false)]
-    per_page: Option<Option<usize>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    per_page: Option<usize>,
 }
 
 impl Pagination {
@@ -68,7 +60,7 @@ impl Pagination {
     /// let params = server::params::Pagination::default();
     /// assert_eq!(params.page(), None);
     /// ```
-    pub fn page(&self) -> Option<Option<usize>> {
+    pub fn page(&self) -> Option<usize> {
         self.page
     }
 
@@ -82,7 +74,7 @@ impl Pagination {
     /// let params = server::params::Pagination::default();
     /// assert_eq!(params.per_page(), None);
     /// ```
-    pub fn per_page(&self) -> Option<Option<usize>> {
+    pub fn per_page(&self) -> Option<usize> {
         self.per_page
     }
 }

--- a/packages/ccdi-server/src/routes/sample.rs
+++ b/packages/ccdi-server/src/routes/sample.rs
@@ -17,7 +17,9 @@ use ccdi_models as models;
 
 use models::Sample;
 
+use crate::filter::filter;
 use crate::paginate;
+use crate::params::filter::Sample as FilterSampleParams;
 use crate::params::Pagination as PaginationParams;
 use crate::responses::by;
 use crate::responses::error;
@@ -50,8 +52,8 @@ impl Store {
             samples: Mutex::new(
                 (0..count)
                     .map(|i| {
-                        // SAFETY: this is manually crafted to never fail, so it can be
-                        // unwrapped.
+                        // SAFETY: this is manually crafted to never fail, so it
+                        // can be unwrapped.
                         let identifier = Identifier::parse(
                             format!("organization:Sample{}", i + 1).as_ref(),
                             ":",
@@ -80,16 +82,66 @@ pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
 
 /// Gets the samples known by this server.
 ///
+/// ### Pagination
+///
 /// This endpoint supports pagination. Pagination is enabled by providing one of
 /// the pagination-related query parameters below.
 ///
-/// **Note:** please read the provided details on default sort order within the
-/// `responses::Samples` schema, as that is a requirement of this endpoint.
+/// ### Filtering
+///
+/// All harmonized (top-level) and unharmonized (nested under the
+/// `metadata.unharmonized` key) metadata fields are filterable. To achieve
+/// this, you can provide the field name as a [`String`]. Filtering follows the
+/// following rules:
+///
+/// * For single-value metadata field, the sample is included in the results if
+///   its value _exactly_ matches the query string. Matches are case-sensitive.
+/// * For multiple-value metadata fields, the sample is included in the results
+///   if any of its values for the field _exactly_ match the query string (a
+///   logical OR [`||`]). Matches are case-sensitive.
+/// * When the metadata field is `null` (in the case of singlular or
+///   multiple-valued metadata fields) or empty, the sample is not included.
+/// * When multiple fields are provided as filters, a logical AND (`&&`) strings
+///   together the predicates. In other words, all filters must match for a
+///   sample to be returned. Note that this means that servers do not natively
+///   support logical OR (`||`) across multiple fields: that must be done by
+///   calling this endpoint with each of your desired queries and performing a
+///   set union of those samples out of band.
+///
+/// ### Ordering
+///
+/// This endpoint has default ordering requirements—those details are documented
+/// in the `responses::Samples` schema.
 #[utoipa::path(
     get,
     path = "/sample",
     tag = "Sample",
-    params(PaginationParams),
+    params(
+        FilterSampleParams,
+        (
+            "metadata.unharmonized.<field>" = Option<String>,
+            Query,
+            nullable = false,
+            description = "All unharmonized fields should be filterable in the \
+            same manner as harmonized fields:\n\n\
+            * Filtering on a singular field should include the `Sample` in \
+            the results if the query exactly matches the value of that field \
+            for the `Sample` (case-sensitive).\n\
+            * Filtering on field with multiple values should include the \
+            `Sample` in the results if the query exactly matches any of the \
+            values of the field for that `Sample` (case-sensitive).\n\
+            * Unlike harmonized fields, unharmonized fields must be prefixed \
+            with `metadata.unharmonized`.\n\n\
+            **Note:** this query parameter is intended to be symbolic of any \
+            unharmonized field. Because of limitations within Swagger UI, it \
+            will show up as a query parameter that can be optionally be \
+            submitted as part of a request within Swagger UI. Please keep in \
+            mind that the literal query parameter \
+            `?metadata.unharmonized.<field>=value` is not supported, so \
+            attempting to use it within Swagger UI will not work!"
+        ),
+        PaginationParams,
+    ),
     responses(
         (
             status = 200,
@@ -159,15 +211,25 @@ pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
     )
 )]
 #[get("/sample")]
-pub async fn sample_index(params: Query<PaginationParams>, samples: Data<Store>) -> impl Responder {
+pub async fn sample_index(
+    filter_params: Query<FilterSampleParams>,
+    pagination_params: Query<PaginationParams>,
+    samples: Data<Store>,
+) -> impl Responder {
     let mut samples = samples.samples.lock().unwrap().clone();
 
     // See the note in the documentation for this endpoint: the results must be
     // sorted by identifier by default.
     samples.sort();
 
-    if params.0.page().is_some() || params.0.per_page().is_some() {
-        paginate::response::<Sample, Samples>(params.0, samples, "http://localhost:8000/sample")
+    let samples = filter::<Sample, FilterSampleParams>(samples, filter_params.0);
+
+    if pagination_params.0.page().is_some() || pagination_params.0.per_page().is_some() {
+        paginate::response::<Sample, Samples>(
+            pagination_params.0,
+            samples,
+            "http://localhost:8000/sample",
+        )
     } else {
         HttpResponse::Ok().json(Samples::from(samples))
     }

--- a/packages/ccdi-server/src/routes/subject.rs
+++ b/packages/ccdi-server/src/routes/subject.rs
@@ -18,7 +18,9 @@ use ccdi_models as models;
 use cde::v1::subject::Identifier;
 use models::Subject;
 
+use crate::filter::filter;
 use crate::paginate;
+use crate::params::filter::Subject as FilterSubjectParams;
 use crate::params::Pagination as PaginationParams;
 use crate::responses::by;
 use crate::responses::error;
@@ -51,8 +53,8 @@ impl Store {
             subjects: Mutex::new(
                 (0..count)
                     .map(|i| {
-                        // SAFETY: this is manually crafted to never fail, so it can be
-                        // unwrapped.
+                        // SAFETY: this is manually crafted to never fail, so it
+                        // can be unwrapped.
                         let identifier = Identifier::parse(
                             format!("organization:Subject{}", i + 1).as_ref(),
                             ":",
@@ -81,16 +83,66 @@ pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
 
 /// Gets the subjects known by this server.
 ///
+/// ### Pagination
+///
 /// This endpoint supports pagination. Pagination is enabled by providing one of
 /// the pagination-related query parameters below.
 ///
-/// **Note:** please read the provided details on default sort order within the
-/// `responses::Subjects` schema, as that is a requirement of this endpoint.
+/// ### Filtering
+///
+/// All harmonized (top-level) and unharmonized (nested under the
+/// `metadata.unharmonized` key) metadata fields are filterable. To achieve
+/// this, you can provide the field name as a [`String`]. Filtering follows the
+/// following rules:
+///
+/// * For single-value metadata field, the subject is included in the results if
+///   its value _exactly_ matches the query string. Matches are case-sensitive.
+/// * For multiple-value metadata fields, the subject is included in the results
+///   if any of its values for the field _exactly_ match the query string (a
+///   logical OR [`||`]). Matches are case-sensitive.
+/// * When the metadata field is `null` (in the case of singlular or
+///   multiple-valued metadata fields) or empty, the subject is not included.
+/// * When multiple fields are provided as filters, a logical AND (`&&`) strings
+///   together the predicates. In other words, all filters must match for a
+///   subject to be returned. Note that this means that servers do not natively
+///   support logical OR (`||`) across multiple fields: that must be done by
+///   calling this endpoint with each of your desired queries and performing a
+///   set union of those subjects out of band.
+///
+/// ### Ordering
+///
+/// This endpoint has default ordering requirements—those details are documented
+/// in the `responses::Subjects` schema.
 #[utoipa::path(
     get,
     path = "/subject",
     tag = "Subject",
-    params(PaginationParams),
+    params(
+        FilterSubjectParams,
+        (
+            "metadata.unharmonized.<field>" = Option<String>,
+            Query,
+            nullable = false,
+            description = "All unharmonized fields should be filterable in the \
+            same manner as harmonized fields:\n\n\
+            * Filtering on a singular field should include the `Subject` in \
+            the results if the query exactly matches the value of that field \
+            for the `Subject` (case-sensitive).\n\
+            * Filtering on field with multiple values should include the \
+            `Subject` in the results if the query exactly matches any of the \
+            values of the field for that `Subject` (case-sensitive).\n\
+            * Unlike harmonized fields, unharmonized fields must be prefixed \
+            with `metadata.unharmonized`.\n\n\
+            **Note:** this query parameter is intended to be symbolic of any \
+            unharmonized field. Because of limitations within Swagger UI, it \
+            will show up as a query parameter that can be optionally be \
+            submitted as part of a request within Swagger UI. Please keep in \
+            mind that the literal query parameter \
+            `?metadata.unharmonized.<field>=value` is not supported, so \
+            attempting to use it within Swagger UI will not work!"
+        ),
+        PaginationParams,
+    ),
     responses(
         (
             status = 200,
@@ -161,7 +213,8 @@ pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
 )]
 #[get("/subject")]
 pub async fn subject_index(
-    params: Query<PaginationParams>,
+    filter_params: Query<FilterSubjectParams>,
+    pagination_params: Query<PaginationParams>,
     subjects: Data<Store>,
 ) -> impl Responder {
     let mut subjects = subjects.subjects.lock().unwrap().clone();
@@ -170,8 +223,14 @@ pub async fn subject_index(
     // sorted by identifier by default.
     subjects.sort();
 
-    if params.0.page().is_some() || params.0.per_page().is_some() {
-        paginate::response::<Subject, Subjects>(params.0, subjects, "http://localhost:8000/subject")
+    let subjects = filter::<Subject, FilterSubjectParams>(subjects, filter_params.0);
+
+    if pagination_params.0.page().is_some() || pagination_params.0.per_page().is_some() {
+        paginate::response::<Subject, Subjects>(
+            pagination_params.0,
+            subjects,
+            "http://localhost:8000/subject",
+        )
     } else {
         HttpResponse::Ok().json(Subjects::from(subjects))
     }

--- a/swagger.yml
+++ b/swagger.yml
@@ -28,13 +28,85 @@ paths:
       description: |-
         Gets the subjects known by this server.
 
+        ### Pagination
+
         This endpoint supports pagination. Pagination is enabled by providing one of
         the pagination-related query parameters below.
 
-        **Note:** please read the provided details on default sort order within the
-        `responses::Subjects` schema, as that is a requirement of this endpoint.
+        ### Filtering
+
+        All harmonized (top-level) and unharmonized (nested under the
+        `metadata.unharmonized` key) metadata fields are filterable. To achieve
+        this, you can provide the field name as a [`String`]. Filtering follows the
+        following rules:
+
+        * For single-value metadata field, the subject is included in the results if
+        its value _exactly_ matches the query string. Matches are case-sensitive.
+        * For multiple-value metadata fields, the subject is included in the results
+        if any of its values for the field _exactly_ match the query string (a
+        logical OR [`||`]). Matches are case-sensitive.
+        * When the metadata field is `null` (in the case of singlular or
+        multiple-valued metadata fields) or empty, the subject is not included.
+        * When multiple fields are provided as filters, a logical AND (`&&`) strings
+        together the predicates. In other words, all filters must match for a
+        subject to be returned. Note that this means that servers do not natively
+        support logical OR (`||`) across multiple fields: that must be done by
+        calling this endpoint with each of your desired queries and performing a
+        set union of those subjects out of band.
+
+        ### Ordering
+
+        This endpoint has default ordering requirements—those details are documented
+        in the `responses::Subjects` schema.
       operationId: subject_index
       parameters:
+      - name: sex
+        in: query
+        description: Matches any subject where the `sex` field matches the string provided.
+        required: false
+        schema:
+          type: string
+      - name: race
+        in: query
+        description: |-
+          Matches any subject where any member of the `race` fieldmatches
+          the string provided.
+
+          **Note:** a logical OR (`||`) is performed across the values when
+          determining whether the subject should be included in the results.
+        required: false
+        schema:
+          type: string
+      - name: ethnicity
+        in: query
+        description: matches any subject where the `ethnicity` field matches the string provided.
+        required: false
+        schema:
+          type: string
+      - name: identifiers
+        in: query
+        description: |-
+          Matches any subject where any member of the `identifiers` fieldmatches
+          the string provided.
+
+          **Note:** a logical OR (`||`) is performed across the values when
+          determining whether the subject should be included in the results.
+        required: false
+        schema:
+          type: string
+      - name: metadata.unharmonized.<field>
+        in: query
+        description: |-
+          All unharmonized fields should be filterable in the same manner as harmonized fields:
+
+          * Filtering on a singular field should include the `Subject` in the results if the query exactly matches the value of that field for the `Subject` (case-sensitive).
+          * Filtering on field with multiple values should include the `Subject` in the results if the query exactly matches any of the values of the field for that `Subject` (case-sensitive).
+          * Unlike harmonized fields, unharmonized fields must be prefixed with `metadata.unharmonized`.
+
+          **Note:** this query parameter is intended to be symbolic of any unharmonized field. Because of limitations within Swagger UI, it will show up as a query parameter that can be optionally be submitted as part of a request within Swagger UI. Please keep in mind that the literal query parameter `?metadata.unharmonized.<field>=value` is not supported, so attempting to use it within Swagger UI will not work!
+        required: false
+        schema:
+          type: string
       - name: page
         in: query
         description: |-
@@ -195,13 +267,75 @@ paths:
       description: |-
         Gets the samples known by this server.
 
+        ### Pagination
+
         This endpoint supports pagination. Pagination is enabled by providing one of
         the pagination-related query parameters below.
 
-        **Note:** please read the provided details on default sort order within the
-        `responses::Samples` schema, as that is a requirement of this endpoint.
+        ### Filtering
+
+        All harmonized (top-level) and unharmonized (nested under the
+        `metadata.unharmonized` key) metadata fields are filterable. To achieve
+        this, you can provide the field name as a [`String`]. Filtering follows the
+        following rules:
+
+        * For single-value metadata field, the sample is included in the results if
+        its value _exactly_ matches the query string. Matches are case-sensitive.
+        * For multiple-value metadata fields, the sample is included in the results
+        if any of its values for the field _exactly_ match the query string (a
+        logical OR [`||`]). Matches are case-sensitive.
+        * When the metadata field is `null` (in the case of singlular or
+        multiple-valued metadata fields) or empty, the sample is not included.
+        * When multiple fields are provided as filters, a logical AND (`&&`) strings
+        together the predicates. In other words, all filters must match for a
+        sample to be returned. Note that this means that servers do not natively
+        support logical OR (`||`) across multiple fields: that must be done by
+        calling this endpoint with each of your desired queries and performing a
+        set union of those samples out of band.
+
+        ### Ordering
+
+        This endpoint has default ordering requirements—those details are documented
+        in the `responses::Samples` schema.
       operationId: sample_index
       parameters:
+      - name: disease_phase
+        in: query
+        description: |-
+          Matches any subject where the `disease_phase` field matches the string
+          provided.
+        required: false
+        schema:
+          type: string
+      - name: tissue_type
+        in: query
+        description: |-
+          Matches any subject where the `tissue_type` field matches the string
+          provided.
+        required: false
+        schema:
+          type: string
+      - name: tumor_classification
+        in: query
+        description: |-
+          Matches any subject where the `tumor_classification` field matches the
+          string provided.
+        required: false
+        schema:
+          type: string
+      - name: metadata.unharmonized.<field>
+        in: query
+        description: |-
+          All unharmonized fields should be filterable in the same manner as harmonized fields:
+
+          * Filtering on a singular field should include the `Sample` in the results if the query exactly matches the value of that field for the `Sample` (case-sensitive).
+          * Filtering on field with multiple values should include the `Sample` in the results if the query exactly matches any of the values of the field for that `Sample` (case-sensitive).
+          * Unlike harmonized fields, unharmonized fields must be prefixed with `metadata.unharmonized`.
+
+          **Note:** this query parameter is intended to be symbolic of any unharmonized field. Because of limitations within Swagger UI, it will show up as a query parameter that can be optionally be submitted as part of a request within Swagger UI. Please keep in mind that the literal query parameter `?metadata.unharmonized.<field>=value` is not supported, so attempting to use it within Swagger UI will not work!
+        required: false
+        schema:
+          type: string
       - name: page
         in: query
         description: |-


### PR DESCRIPTION
**PR Close Date:** November 17, 2023

This pull request adds filtering using query parameters to the `/sample` and `/subject` endpoints.

### Parameter Naming

* I have embedded all of the harmonized keys as top-level objects that can be filtered (`?sex=F`, `?race=Unknown`, etc). This is because we can control the namespace for these values and ensure that they don't collide with other top-level query parameters (`page` and `per_page`, for example). It is also more convenient to not have to prefix everything with `metadata.`.
* Unharmonized keys currently require the prefix `metadata.unharmonized`. This is, again, to namespace the keys.

I am not 100% sure this is the right approach, but I wanted to put it out there and see what people thought.

### Filtering

All harmonized (top-level) and unharmonized (nested under the `metadata.unharmonized` key) metadata fields are filterable. To achieve this, you can provide the field name as a string.

Filtering follows the following rules:

* For single-value metadata field, the sample is included in the results if its value _exactly_ matches the query string. Matches are case-sensitive.
* For multiple-value metadata fields, the sample is included in the results if any of its values for the field _exactly_ match the query string (a logical OR [`||`]). In the rare case an empty array is provided, no values can match, so the entity will always be filtered out. Matches are case-sensitive.
* When no metadata field is provided (i.e., the value of the `metadata` key is `null`) or the `metadata` is present but the field in question is `null` (possible for both singular and multiple-valued metadata fields).
* When multiple fields are provided as filters, a logical AND (`&&`) string together the predicates. In other words, all filters must match for a sample to be returned. Note that this means that servers do not natively support logical OR (`||`) across multiple fields: that must be done by calling this endpoint with each of your desired queries and performing aset union of those samples out of band.

### Value Matching

At first, I implemented the filtering as required the provided parameter to be a **substring** of the entity's value (as opposed to exact matching, which is what I settled on for this PR). This became problematic when, for instance, I was filtering for `?sex=F` and, because `UNDIFFERENTIATED` contains an `F`, those were coming back in my results. 

For now, I have also required case-sensitive matching. I wanted to hear from folks whether they thought this was the right approach. Briefly, since we are requiring exact matching for the reason I listed above, I felt that keeping the exact casing was in step with that.

I think exact matching is a fine enough strategy for now—I would not, however, be opposed to adding case-insensitive and inexact matching in the future if there is interest. I do think those two concepts go hand in hand so, if we want to implement them, we should do it at the same time.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
