### PR TITLE
feat: adds missing route error

### DIFF
--- a/packages/ccdi-openapi/src/api.rs
+++ b/packages/ccdi-openapi/src/api.rs
@@ -15,10 +15,17 @@ use utoipa::openapi;
 #[openapi(
     info(
         title = "CCDI Pediatric Cancer Data Catalog",
-        description = "The CCDI Pediatric Cancer Data Catalog is an API that supports the querying
-of federated pediatric cancer within the broader community. The goal of the
-API is to support identification of pediatric cancer samples of interest via
-a variety of query parameters.",
+        description = "The CCDI Pediatric Cancer Data Catalog is an API that 
+supports the querying of federated pediatric cancer within the broader 
+community. The goal of the API is to support identification of pediatric cancer 
+samples of interest via a variety of query parameters. 
+
+### Invalid Routes
+
+All responses that do not match an endpoint below should return a Not Found 
+(`404`) response. The body of this response should be the `responses.Errors` 
+JSON object with one `responses.error.Kind` where the `Kind` matches the 
+`InvalidRoute` error.",
         contact(
             name = "Childhood Cancer Data Initiative support email",
             email = "NCIChildhoodCancerDataInitiative@mail.nih.gov",

--- a/packages/ccdi-server/src/responses/error.rs
+++ b/packages/ccdi-server/src/responses/error.rs
@@ -29,7 +29,7 @@ impl std::fmt::Display for Errors {
             .iter()
             .map(|s| s.to_string())
             .collect::<Vec<_>>()
-            .join(",");
+            .join(", ");
         write!(f, "errors: {errors}")
     }
 }
@@ -92,6 +92,19 @@ impl From<Kind> for Errors {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn invalid_route() -> Result<(), Box<dyn std::error::Error>> {
+        let errors = Errors::from(Kind::invalid_route(
+            String::from("GET"),
+            String::from("/foobar"),
+        ));
+
+        let result = serde_json::to_string(&errors)?;
+        assert_eq!(&result, "{\"errors\":[{\"kind\":\"InvalidRoute\",\"method\":\"GET\",\"route\":\"/foobar\",\"message\":\"Invalid route: GET /foobar.\"}]}");
+
+        Ok(())
+    }
 
     #[test]
     fn invalid_parameter() -> Result<(), Box<dyn std::error::Error>> {

--- a/packages/ccdi-server/src/responses/error/kind.rs
+++ b/packages/ccdi-server/src/responses/error/kind.rs
@@ -44,6 +44,7 @@ impl ResponseError for Kind {
             Inner::NotFound { .. } => StatusCode::NOT_FOUND,
             Inner::UnsupportedField { .. } => StatusCode::UNPROCESSABLE_ENTITY,
             Inner::UnshareableData { .. } => StatusCode::NOT_FOUND,
+            Inner::InvalidRoute { .. } => StatusCode::NOT_FOUND,
         }
     }
 
@@ -55,6 +56,31 @@ impl ResponseError for Kind {
 }
 
 impl Kind {
+    /// Creates a new [Kind] with an [`InvalidRoute`](Inner::InvalidRoute) inner.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_server as server;
+    ///
+    /// let error = server::responses::error::Kind::invalid_route(
+    ///     String::from("GET"),
+    ///     String::from("/foobar")
+    /// );
+    ///
+    /// assert_eq!(serde_json::to_string(&error)?, String::from("{\"kind\":\"InvalidRoute\",\"method\":\"GET\",\"route\":\"/foobar\",\"message\":\"Invalid route: GET /foobar.\"}"));
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn invalid_route(method: String, route: String) -> Self {
+        let inner = Inner::invalid_route(method, route);
+
+        Self {
+            message: inner.to_string(),
+            inner,
+        }
+    }
+
     /// Creates a new [Kind] with an [`InvalidParameters`](Inner::InvalidParameters) inner.
     ///
     /// # Examples

--- a/packages/ccdi-spec/src/main.rs
+++ b/packages/ccdi-spec/src/main.rs
@@ -6,9 +6,12 @@ use std::path::PathBuf;
 use actix_web::error::QueryPayloadError;
 use actix_web::middleware::Logger;
 use actix_web::rt;
+use actix_web::web;
 use actix_web::web::Data;
 use actix_web::web::QueryConfig;
 use actix_web::App;
+use actix_web::HttpRequest;
+use actix_web::HttpResponse;
 use actix_web::HttpServer;
 use clap::Parser;
 use clap::Subcommand;
@@ -177,6 +180,12 @@ fn inner() -> Result<(), Box<dyn std::error::Error>> {
                             SwaggerUi::new("/swagger-ui/{_:.*}")
                                 .url("/api-docs/openapi.json", Api::openapi()),
                         )
+                        .default_service(web::to(|req: HttpRequest| async move {
+                            HttpResponse::NotFound().json(Errors::from(error::Kind::invalid_route(
+                                req.method().to_string(),
+                                req.path().to_string(),
+                            )))
+                        }))
                 })
                 .bind((Ipv4Addr::UNSPECIFIED, args.port))?
                 .run(),

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,11 +1,7 @@
 openapi: 3.0.3
 info:
   title: CCDI Pediatric Cancer Data Catalog
-  description: |-
-    The CCDI Pediatric Cancer Data Catalog is an API that supports the querying
-    of federated pediatric cancer within the broader community. The goal of the
-    API is to support identification of pediatric cancer samples of interest via
-    a variety of query parameters.
+  description: "The CCDI Pediatric Cancer Data Catalog is an API that \nsupports the querying of federated pediatric cancer within the broader \ncommunity. The goal of the API is to support identification of pediatric cancer \nsamples of interest via a variety of query parameters. \n\n### Invalid Routes\n\nAll responses that do not match an endpoint below should return a Not Found \n(`404`) response. The body of this response should be the `responses.Errors` \nJSON object with one `responses.error.Kind` where the `Kind` matches the \n`InvalidRoute` error."
   contact:
     name: Childhood Cancer Data Initiative support email
     email: NCIChildhoodCancerDataInitiative@mail.nih.gov
@@ -1320,6 +1316,31 @@ components:
     responses.error.Kind:
       allOf:
       - oneOf:
+        - type: object
+          description: |-
+            Attempted to access an invalid route.
+
+            Also includes all routes for which the path exists, but the HTTP method
+            is not supported for that path.
+          required:
+          - method
+          - route
+          - kind
+          properties:
+            method:
+              type: string
+              description: The HTTP method that was used in the request.
+            route:
+              type: string
+              description: The route that was requested.
+            kind:
+              type: string
+              enum:
+              - InvalidRoute
+          example:
+            kind: InvalidRoute
+            method: GET
+            route: /foobar
         - type: object
           description: One or more invalid query or path parameters were provided.
           required:


### PR DESCRIPTION
**PR Close Date:** November 24, 2023

Adds an error for a missing route. Unfortunately, I could not find a way to define the default response for any non-matching route within the OpenAPI specification. As such, I have added a section to the description that defines this requirement.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
