### PR TITLE
revise: adds unshareable data error

### DIFF
--- a/packages/ccdi-server/src/responses/error/kind.rs
+++ b/packages/ccdi-server/src/responses/error/kind.rs
@@ -43,6 +43,7 @@ impl ResponseError for Kind {
             Inner::InvalidParameters { .. } => StatusCode::UNPROCESSABLE_ENTITY,
             Inner::NotFound { .. } => StatusCode::NOT_FOUND,
             Inner::UnsupportedField { .. } => StatusCode::UNPROCESSABLE_ENTITY,
+            Inner::UnshareableData { .. } => StatusCode::NOT_FOUND,
         }
     }
 
@@ -106,6 +107,35 @@ impl Kind {
     /// ```
     pub fn not_found(entity: String) -> Self {
         let inner = Inner::not_found(entity);
+
+        Self {
+            message: inner.to_string(),
+            inner,
+        }
+    }
+
+    /// Creates a new [Kind] with an
+    /// [`UnshareableData`](Inner::UnshareableData) inner.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_server as server;
+    ///
+    /// let error = server::responses::error::Kind::unshareable_data(
+    ///     String::from("samples"),
+    ///     String::from(
+    ///         "Our agreement with data providers prohibits us from sharing \
+    ///         line-level data."
+    ///     ),
+    /// );
+    ///
+    /// assert_eq!(serde_json::to_string(&error)?, String::from("{\"kind\":\"UnshareableData\",\"entity\":\"Samples\",\"reason\":\"Our agreement with data providers prohibits us from sharing line-level data.\",\"message\":\"Unable to share data for samples: our agreement with data providers prohibits us from sharing line-level data.\"}"));
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn unshareable_data(entity: String, reason: String) -> Self {
+        let inner = Inner::unshareable_data(entity, reason);
 
         Self {
             message: inner.to_string(),

--- a/packages/ccdi-server/src/routes/sample.rs
+++ b/packages/ccdi-server/src/routes/sample.rs
@@ -203,7 +203,17 @@ pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
             there is no level of authorization that would allow one to access \
             the information included in the API.",
             body = responses::Errors,
-            example = json!(Errors::from(error::Kind::not_found(String::from("Samples"))))
+            example = json!(
+                Errors::from(
+                    error::Kind::unshareable_data(
+                        String::from("samples"),
+                        String::from(
+                            "Our agreement with data providers prohibits us from sharing \
+                            line-level data."
+                        ),
+                    )
+                )
+            )
         ),
         (
             status = 422,

--- a/packages/ccdi-server/src/routes/subject.rs
+++ b/packages/ccdi-server/src/routes/subject.rs
@@ -198,7 +198,17 @@ pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
             there is no level of authorization that would allow one to access \
             the information included in the API.",
             body = responses::Errors,
-            example = json!(Errors::from(error::Kind::not_found(String::from("Subjects"))))
+            example = json!(
+                Errors::from(
+                    error::Kind::unshareable_data(
+                        String::from("subjects"),
+                        String::from(
+                            "Our agreement with data providers prohibits us from sharing \
+                            line-level data."
+                        ),
+                    )
+                )
+            )
         ),
         (
             status = 422,

--- a/swagger.yml
+++ b/swagger.yml
@@ -155,9 +155,10 @@ paths:
                 $ref: '#/components/schemas/responses.Errors'
               example:
                 errors:
-                - kind: NotFound
+                - kind: UnshareableData
                   entity: Subjects
-                  message: Subjects not found.
+                  reason: Our agreement with data providers prohibits us from sharing line-level data.
+                  message: 'Unable to share data for subjects: our agreement with data providers prohibits us from sharing line-level data.'
         '422':
           description: Invalid query or path parameters.
           content:
@@ -384,9 +385,10 @@ paths:
                 $ref: '#/components/schemas/responses.Errors'
               example:
                 errors:
-                - kind: NotFound
+                - kind: UnshareableData
                   entity: Samples
-                  message: Samples not found.
+                  reason: Our agreement with data providers prohibits us from sharing line-level data.
+                  message: 'Unable to share data for samples: our agreement with data providers prohibits us from sharing line-level data.'
         '422':
           description: Invalid query or path parameters.
           content:
@@ -1217,6 +1219,27 @@ components:
           example:
             kind: NotFound
             entity: Samples
+        - type: object
+          description: Line-level data cannot be shared for the specified entity.
+          required:
+          - entity
+          - reason
+          - kind
+          properties:
+            entity:
+              type: string
+              description: The entity (or entities) where data cannot be shared.
+            reason:
+              type: string
+              description: The reason that the line-level data cannot be shared.
+            kind:
+              type: string
+              enum:
+              - UnshareableData
+          example:
+            kind: UnshareableData
+            entity: Sample
+            reason: Our agreement with data providers prohibits us from sharing line-level data.
         - type: object
           description: A field name was not supported for the attempted operation.
           required:


### PR DESCRIPTION
**PR Close Date:** November 24, 2023

This PR adds a new error that is more specific when describing a situation when line-level data cannot be shared. I intentionally named it `UnshareableData` to encompass other cases where data cannot be shared for whatever reason.

@grugna, let me know if this response will be sufficient for your purposes.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
