### PR TITLE
feat: adds five new harmonized metadata elements

### DIFF
--- a/packages/Cargo.lock
+++ b/packages/Cargo.lock
@@ -422,9 +422,11 @@ dependencies = [
  "ccdi-cde",
  "chrono",
  "indexmap 2.0.2",
+ "introspect",
  "lazy_static",
  "macropol",
  "nonempty",
+ "ordered-float",
  "rand",
  "regex",
  "serde",
@@ -1395,6 +1397,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
+dependencies = [
+ "num-traits",
+ "rand",
+ "serde",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,6 +1517,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -1523,6 +1537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]

--- a/packages/Cargo.toml
+++ b/packages/Cargo.toml
@@ -23,6 +23,7 @@ lazy_static = "1.4.0"
 log = "0.4.20"
 mime = "0.3.17"
 nonempty = { version = "0.9.0", features = ["serialize"] }
+ordered-float = { version = "4.0", features = ["serde"] }
 rand = "0.8.5"
 regex = "1.10.2"
 reqwest = { version = "0.11.22", features = ["blocking", "json"] }

--- a/packages/ccdi-cde/src/lib.rs
+++ b/packages/ccdi-cde/src/lib.rs
@@ -110,7 +110,7 @@ mod tests {
     fn entity_parsing_works_correctly() {
         let entity = Sex::entity().unwrap();
 
-        assert_eq!(entity.standard(), "caDSR CDE 6343385 v1.00");
+        assert_eq!(entity.standard_name(), "caDSR CDE 6343385 v1.00");
     }
 
     #[test]

--- a/packages/ccdi-cde/src/parse/cde/entity.rs
+++ b/packages/ccdi-cde/src/parse/cde/entity.rs
@@ -72,37 +72,12 @@ pub type Result<T> = std::result::Result<T, ParseError>;
 /// `struct` or an `enum` (both can be used to describe common data elements).
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Entity {
-    standard: String,
     description: String,
-    url: Url,
+    standard_name: String,
+    standard_url: Url,
 }
 
 impl Entity {
-    /// Gets the standard for the [`Entity`] by reference.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use ccdi_cde as cde;
-    ///
-    /// use cde::parse::cde::Entity;
-    ///
-    /// let entity = r#"**`A Standard`**
-    ///
-    /// A description that spans
-    /// multiple lines.
-    ///
-    /// Link: <https://example.com>"#
-    ///     .parse::<Entity>()?;
-    ///
-    /// assert_eq!(entity.standard(), "A Standard");
-    ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    pub fn standard(&self) -> &str {
-        self.standard.as_str()
-    }
-
     /// Gets the description for the [`Entity`] by reference.
     ///
     /// # Examples
@@ -131,7 +106,7 @@ impl Entity {
         self.description.as_str()
     }
 
-    /// Gets the URL for the [`Entity`] by reference.
+    /// Gets the standard name for the [`Entity`] by reference.
     ///
     /// # Examples
     ///
@@ -148,12 +123,37 @@ impl Entity {
     /// Link: <https://example.com>"#
     ///     .parse::<Entity>()?;
     ///
-    /// assert_eq!(entity.url().as_str(), "https://example.com/");
+    /// assert_eq!(entity.standard_name(), "A Standard");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn url(&self) -> &Url {
-        &self.url
+    pub fn standard_name(&self) -> &str {
+        self.standard_name.as_str()
+    }
+
+    /// Gets the standard URL for the [`Entity`] by reference.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_cde as cde;
+    ///
+    /// use cde::parse::cde::Entity;
+    ///
+    /// let entity = r#"**`A Standard`**
+    ///
+    /// A description that spans
+    /// multiple lines.
+    ///
+    /// Link: <https://example.com>"#
+    ///     .parse::<Entity>()?;
+    ///
+    /// assert_eq!(entity.standard_url().as_str(), "https://example.com/");
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn standard_url(&self) -> &Url {
+        &self.standard_url
     }
 }
 
@@ -173,9 +173,9 @@ impl std::str::FromStr for Entity {
         let url = Url::parse(&url).map_err(ParseError::InvalidURL)?;
 
         Ok(Self {
-            standard,
+            standard_name: standard,
             description,
-            url,
+            standard_url: url,
         })
     }
 }
@@ -261,7 +261,10 @@ mod tests {
         Link: <https://example.com>"#
             .parse::<Entity>()?;
 
-        assert_eq!(entity.standard(), "A Standard That Spans Multiple Lines");
+        assert_eq!(
+            entity.standard_name(),
+            "A Standard That Spans Multiple Lines"
+        );
 
         Ok(())
     }
@@ -277,7 +280,7 @@ mod tests {
         <https://example.com>"#
             .parse::<Entity>()?;
 
-        assert_eq!(entity.url().as_str(), "https://example.com/");
+        assert_eq!(entity.standard_url().as_str(), "https://example.com/");
 
         Ok(())
     }

--- a/packages/ccdi-cde/src/v1/sample.rs
+++ b/packages/ccdi-cde/src/v1/sample.rs
@@ -3,6 +3,8 @@
 
 mod disease_phase;
 mod tumor_classification;
+mod tumor_tissue_morphology;
 
 pub use disease_phase::DiseasePhase;
 pub use tumor_classification::TumorClassification;
+pub use tumor_tissue_morphology::TumorTissueMorphology;

--- a/packages/ccdi-cde/src/v1/sample/tumor_tissue_morphology.rs
+++ b/packages/ccdi-cde/src/v1/sample/tumor_tissue_morphology.rs
@@ -1,0 +1,36 @@
+use introspect::Introspect;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use crate::CDE;
+
+/// **`caDSR CDE 11326261 v1.00`**
+///
+/// This metadata element is defined by the caDSR as "The microscopic anatomy of
+/// normal and abnormal cells and tissues of the specimen as captured in the
+/// morphology codes of the International Classification of Diseases for
+/// Oncology, 3rd Edition (ICD-O-3)."
+///
+/// Link:
+/// <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11326261%20and%20ver_nr=1>
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema, Introspect)]
+#[schema(as = cde::v1::sample::TumorTissueMorphology)]
+pub struct TumorTissueMorphology(
+    /// The ICD-O-3 code.
+    String,
+);
+
+impl From<String> for TumorTissueMorphology {
+    fn from(value: String) -> Self {
+        TumorTissueMorphology(value)
+    }
+}
+
+impl CDE for TumorTissueMorphology {}
+
+impl std::fmt::Display for TumorTissueMorphology {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/packages/ccdi-cde/src/v1/subject.rs
+++ b/packages/ccdi-cde/src/v1/subject.rs
@@ -4,7 +4,9 @@
 pub mod identifier;
 mod race;
 mod sex;
+mod vital_status;
 
 pub use identifier::Identifier;
 pub use race::Race;
 pub use sex::Sex;
+pub use vital_status::VitalStatus;

--- a/packages/ccdi-cde/src/v1/subject/vital_status.rs
+++ b/packages/ccdi-cde/src/v1/subject/vital_status.rs
@@ -1,0 +1,96 @@
+use introspect::Introspect;
+use rand::distributions::Standard;
+use rand::prelude::Distribution;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use crate::CDE;
+
+/// **`caDSR CDE 2847330 v1.00`**
+///
+/// This metadata element is defined by the caDSR as "The response to a question
+/// that describes a participant's survival status."
+///
+/// Link:
+/// <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=2847330%20and%20ver_nr=1>
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema, Introspect)]
+#[schema(as = cde::v1::subject::VitalStatus)]
+pub enum VitalStatus {
+    /// `Not reported`
+    ///
+    /// * **VM Long Name**: Not Reported
+    /// * **VM Public ID**: 2572231
+    /// * **Concept Code**: C43234
+    /// * **Begin Date**:   12/29/2020
+    ///
+    /// Not provided or available.
+    #[serde(rename = "Not reported")]
+    NotReported,
+
+    /// `Alive`
+    ///
+    /// * **VM Long Name**: Alive
+    /// * **VM Public ID**: 2580948
+    /// * **Concept Code**: C37987
+    /// * **Begin Date**:   03/09/2009
+    ///
+    /// Showing characteristics of life; displaying signs of life.
+    Alive,
+
+    /// `Dead`
+    ///
+    /// * **VM Long Name**: Death
+    /// * **VM Public ID**: 2847328
+    /// * **Concept Code**: C28554
+    /// * **Begin Date**:   03/09/2009
+    ///
+    /// The absence of life or state of being dead.
+    Dead,
+
+    /// `Unknown`
+    ///
+    /// * **VM Long Name**: Unknown
+    /// * **VM Public ID**: 2575365
+    /// * **Concept Code**: C17998
+    /// * **Begin Date**:   03/09/2009
+    ///
+    /// Not known, not observed, not recorded, or refused.
+    Unknown,
+
+    /// `Unspecified`
+    ///
+    /// * **VM Long Name**: Unspecified
+    /// * **VM Public ID**: 2573360
+    /// * **Concept Code**: C38046
+    /// * **Begin Date**:   03/09/2009
+    ///
+    /// Not stated explicitly or in detail.
+    Unspecified,
+}
+
+impl CDE for VitalStatus {}
+
+impl std::fmt::Display for VitalStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VitalStatus::NotReported => write!(f, "Not reported"),
+            VitalStatus::Alive => write!(f, "Alive"),
+            VitalStatus::Dead => write!(f, "Dead"),
+            VitalStatus::Unknown => write!(f, "Unknown"),
+            VitalStatus::Unspecified => write!(f, "Unspecified"),
+        }
+    }
+}
+
+impl Distribution<VitalStatus> for Standard {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> VitalStatus {
+        match rng.gen_range(0..=4) {
+            0 => VitalStatus::NotReported,
+            1 => VitalStatus::Alive,
+            2 => VitalStatus::Dead,
+            3 => VitalStatus::Unknown,
+            _ => VitalStatus::Unspecified,
+        }
+    }
+}

--- a/packages/ccdi-cde/src/v2.rs
+++ b/packages/ccdi-cde/src/v2.rs
@@ -1,4 +1,4 @@
-//! Common data elements that have a major version of one.
+//! Common data elements that have a major version of two.
 
 pub mod sample;
 pub mod subject;

--- a/packages/ccdi-models/Cargo.toml
+++ b/packages/ccdi-models/Cargo.toml
@@ -8,9 +8,11 @@ edition.workspace = true
 ccdi-cde = { path = "../ccdi-cde" }
 chrono.workspace = true
 indexmap.workspace = true
+introspect.workspace = true
 lazy_static.workspace = true
 macropol = "0.1.3"
 nonempty.workspace = true
+ordered-float.workspace = true
 rand.workspace = true
 regex.workspace = true
 serde.workspace = true

--- a/packages/ccdi-models/src/metadata/field/description.rs
+++ b/packages/ccdi-models/src/metadata/field/description.rs
@@ -26,14 +26,12 @@ pub enum Description {
 
 /// Traits related to a [`Description`].
 pub mod r#trait {
-    use ccdi_cde as cde;
+    use introspect::Introspected;
 
-    use cde::CDE;
-
-    /// A trait to get a [`Description`] for a [`CDE`].
+    /// A trait to get a [`Description`] for an [`Introspected`] entity.
     pub trait Description
     where
-        Self: CDE + Sized,
+        Self: Introspected + Sized,
     {
         /// Gets the [`Description`].
         fn description() -> super::Description;

--- a/packages/ccdi-models/src/metadata/field/description/harmonized.rs
+++ b/packages/ccdi-models/src/metadata/field/description/harmonized.rs
@@ -6,13 +6,25 @@ use utoipa::ToSchema;
 
 use ccdi_cde as cde;
 
-use cde::parse::cde::Entity;
 use cde::parse::cde::Member;
 
 use crate::Url;
 
 pub mod sample;
+mod standard;
 pub mod subject;
+
+pub use standard::Standard;
+
+/// A kind of harmonized value.
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema)]
+pub enum Kind {
+    /// An enum.
+    Enum,
+
+    /// A struct.
+    Struct,
+}
 
 /// A harmonized metadata field description.
 ///
@@ -26,26 +38,36 @@ pub struct Harmonized {
     #[schema(default = true)]
     harmonized: bool,
 
+    /// The kind of harmonized metadata field.
+    #[serde(skip_serializing)]
+    kind: Kind,
+
     /// A comma (`.`) delimited path to the field's location on the `metadata`
     /// objects returned by the various subject endpoints.
     path: String,
 
-    /// The proper name of the standard to which this field is harmonized (defined
-    /// by the documentation for the CCDI metadata fields).
-    standard: String,
+    /// A description of the harmonized metadata field.
+    #[serde(skip_serializing)]
+    description: String,
 
-    /// A URL to the CCDI documentation where the definition of this harmonized
-    /// field resides.
+    /// A URL to the CCDI wiki documentation where the definition of this
+    /// harmonized field resides.
     #[schema(value_type = models::Url)]
-    url: Url,
+    wiki_url: Url,
 
-    /// The parsed [`Entity`].
-    #[serde(skip_serializing)]
-    entity: Entity,
+    /// If available, the standard to which this field is harmonized (this field
+    /// is defined by the documentation for the CCDI metadata fields when the
+    /// field is backed by a CDE).
+    #[schema(value_type = Option<models::metadata::field::description::harmonized::Standard>)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    standard: Option<Standard>,
 
-    /// The parsed [`Member`]s and their respective identifiers of the entity.
+    /// If present, the parsed [`Member`]s and their respective identifiers of
+    /// the entity. For a `struct`, this equates to each of the members within
+    /// the `struct`. For an `enum`, this is all of the available variants for
+    /// the `enum`.
     #[serde(skip_serializing)]
-    members: Vec<(String, Member)>,
+    members: Option<Vec<(String, Member)>>,
 }
 
 impl Harmonized {
@@ -60,20 +82,21 @@ impl Harmonized {
     /// use cde::parse::cde::member::Variant;
     /// use cde::parse::cde::Entity;
     /// use cde::parse::cde::Member;
+    /// use models::metadata::field::description::harmonized::Kind;
+    /// use models::metadata::field::description::harmonized::Standard;
     /// use models::metadata::field::description::Harmonized;
     /// use models::Url;
     ///
     /// let description = Harmonized::new(
-    ///     String::from("test"),
-    ///     String::from("caDSR ------ v1.00"),
-    ///     Url::try_from("https://cancer.gov").unwrap(),
-    ///     "**`A Standard`**
-    ///     
-    ///     A description for the entity.
-    ///
-    ///     Link: <https://example.com>"
-    ///         .parse::<Entity>()?,
-    ///     vec![(
+    ///     Kind::Enum,
+    ///     String::from("entity"),
+    ///     String::from("A description for the entity."),
+    ///     Url::try_from("https://github.com/CBIIT/ccdi-federation-api/wiki").unwrap(),
+    ///     Some(Standard::new(
+    ///         String::from("caDSR ------ v1.00"),
+    ///         Url::try_from("https://cancer.gov").unwrap(),
+    ///     )),
+    ///     Some(vec![(
     ///         String::from("Unknown"),
     ///         Member::Variant(
     ///             "`Unknown`
@@ -82,26 +105,73 @@ impl Harmonized {
     ///                 .parse::<Variant>()
     ///                 .unwrap(),
     ///         ),
-    ///     )],
+    ///     )]),
     /// );
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn new(
+        kind: Kind,
         path: String,
-        standard: String,
-        url: Url,
-        entity: Entity,
-        members: Vec<(String, Member)>,
+        description: String,
+        wiki_url: Url,
+        standard: Option<Standard>,
+        members: Option<Vec<(String, Member)>>,
     ) -> Self {
         Harmonized {
             harmonized: true,
+            kind,
             path,
+            description,
+            wiki_url,
             standard,
-            url,
-            entity,
             members,
         }
+    }
+
+    /// Gets the [`Kind`] of the [`Harmonized`] by reference.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_cde as cde;
+    /// use ccdi_models as models;
+    ///
+    /// use cde::parse::cde::member::Variant;
+    /// use cde::parse::cde::Entity;
+    /// use cde::parse::cde::Member;
+    /// use models::metadata::field::description::harmonized::Kind;
+    /// use models::metadata::field::description::harmonized::Standard;
+    /// use models::metadata::field::description::Harmonized;
+    /// use models::Url;
+    ///
+    /// let description = Harmonized::new(
+    ///     Kind::Enum,
+    ///     String::from("entity"),
+    ///     String::from("A description for the entity."),
+    ///     Url::try_from("https://github.com/CBIIT/ccdi-federation-api/wiki").unwrap(),
+    ///     Some(Standard::new(
+    ///         String::from("caDSR ------ v1.00"),
+    ///         Url::try_from("https://cancer.gov").unwrap(),
+    ///     )),
+    ///     Some(vec![(
+    ///         String::from("Unknown"),
+    ///         Member::Variant(
+    ///             "`Unknown`
+    ///              
+    ///             A description for the variant."
+    ///                 .parse::<Variant>()
+    ///                 .unwrap(),
+    ///         ),
+    ///     )]),
+    /// );
+    ///
+    /// assert_eq!(description.kind(), &Kind::Enum);
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn kind(&self) -> &Kind {
+        &self.kind
     }
 
     /// Gets the path of the [`Harmonized`] by reference.
@@ -115,20 +185,21 @@ impl Harmonized {
     /// use cde::parse::cde::member::Variant;
     /// use cde::parse::cde::Entity;
     /// use cde::parse::cde::Member;
+    /// use models::metadata::field::description::harmonized::Kind;
+    /// use models::metadata::field::description::harmonized::Standard;
     /// use models::metadata::field::description::Harmonized;
     /// use models::Url;
     ///
     /// let description = Harmonized::new(
-    ///     String::from("test"),
-    ///     String::from("caDSR ------ v1.00"),
-    ///     Url::try_from("https://cancer.gov").unwrap(),
-    ///     "**`A Standard`**
-    ///     
-    ///     A description for the entity.
-    ///
-    ///     Link: <https://example.com>"
-    ///         .parse::<Entity>()?,
-    ///     vec![(
+    ///     Kind::Enum,
+    ///     String::from("entity"),
+    ///     String::from("A description for the entity."),
+    ///     Url::try_from("https://github.com/CBIIT/ccdi-federation-api/wiki").unwrap(),
+    ///     Some(Standard::new(
+    ///         String::from("caDSR ------ v1.00"),
+    ///         Url::try_from("https://cancer.gov").unwrap(),
+    ///     )),
+    ///     Some(vec![(
     ///         String::from("Unknown"),
     ///         Member::Variant(
     ///             "`Unknown`
@@ -137,19 +208,18 @@ impl Harmonized {
     ///                 .parse::<Variant>()
     ///                 .unwrap(),
     ///         ),
-    ///     )],
+    ///     )]),
     /// );
     ///
-    /// assert_eq!(description.path(), &String::from("test"));
+    /// assert_eq!(description.path(), "entity");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn path(&self) -> &String {
-        &self.path
+    pub fn path(&self) -> &str {
+        self.path.as_str()
     }
 
-    /// Gets the harmonization standard name of the [`Harmonized`] by
-    /// reference.
+    /// Gets the description for the [`Harmonized`] by reference.
     ///
     /// # Examples
     ///
@@ -160,20 +230,21 @@ impl Harmonized {
     /// use cde::parse::cde::member::Variant;
     /// use cde::parse::cde::Entity;
     /// use cde::parse::cde::Member;
+    /// use models::metadata::field::description::harmonized::Kind;
+    /// use models::metadata::field::description::harmonized::Standard;
     /// use models::metadata::field::description::Harmonized;
     /// use models::Url;
     ///
     /// let description = Harmonized::new(
-    ///     String::from("test"),
-    ///     String::from("caDSR ------ v1.00"),
-    ///     Url::try_from("https://cancer.gov").unwrap(),
-    ///     "**`A Standard`**
-    ///     
-    ///     A description for the entity.
-    ///
-    ///     Link: <https://example.com>"
-    ///         .parse::<Entity>()?,
-    ///     vec![(
+    ///     Kind::Enum,
+    ///     String::from("entity"),
+    ///     String::from("A description for the entity."),
+    ///     Url::try_from("https://github.com/CBIIT/ccdi-federation-api/wiki").unwrap(),
+    ///     Some(Standard::new(
+    ///         String::from("caDSR ------ v1.00"),
+    ///         Url::try_from("https://cancer.gov").unwrap(),
+    ///     )),
+    ///     Some(vec![(
     ///         String::from("Unknown"),
     ///         Member::Variant(
     ///             "`Unknown`
@@ -182,19 +253,18 @@ impl Harmonized {
     ///                 .parse::<Variant>()
     ///                 .unwrap(),
     ///         ),
-    ///     )],
+    ///     )]),
     /// );
     ///
-    /// assert_eq!(description.standard(), &String::from("caDSR ------ v1.00"));
+    /// assert_eq!(description.description(), "A description for the entity.");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn standard(&self) -> &String {
-        &self.standard
+    pub fn description(&self) -> &str {
+        self.description.as_str()
     }
 
-    /// Gets the URL for which one can learn more about the [`Harmonized`] by
-    /// reference.
+    /// Gets the wiki URL for the [`Harmonized`] by reference.
     ///
     /// # Examples
     ///
@@ -205,20 +275,21 @@ impl Harmonized {
     /// use cde::parse::cde::member::Variant;
     /// use cde::parse::cde::Entity;
     /// use cde::parse::cde::Member;
+    /// use models::metadata::field::description::harmonized::Kind;
+    /// use models::metadata::field::description::harmonized::Standard;
     /// use models::metadata::field::description::Harmonized;
     /// use models::Url;
     ///
     /// let description = Harmonized::new(
-    ///     String::from("test"),
-    ///     String::from("caDSR ------ v1.00"),
-    ///     Url::try_from("https://cancer.gov").unwrap(),
-    ///     "**`A Standard`**
-    ///     
-    ///     A description for the entity.
-    ///
-    ///     Link: <https://example.com>"
-    ///         .parse::<Entity>()?,
-    ///     vec![(
+    ///     Kind::Enum,
+    ///     String::from("entity"),
+    ///     String::from("A description for the entity."),
+    ///     Url::try_from("https://github.com/CBIIT/ccdi-federation-api/wiki").unwrap(),
+    ///     Some(Standard::new(
+    ///         String::from("caDSR ------ v1.00"),
+    ///         Url::try_from("https://cancer.gov").unwrap(),
+    ///     )),
+    ///     Some(vec![(
     ///         String::from("Unknown"),
     ///         Member::Variant(
     ///             "`Unknown`
@@ -227,64 +298,65 @@ impl Harmonized {
     ///                 .parse::<Variant>()
     ///                 .unwrap(),
     ///         ),
-    ///     )],
+    ///     )]),
     /// );
     ///
-    /// assert_eq!(description.url().as_str(), "https://cancer.gov/");
-    ///
-    /// # Ok::<(), Box<dyn std::error::Error>>(())
-    /// ```
-    pub fn url(&self) -> &Url {
-        &self.url
-    }
-
-    /// Gets the entity for the [`Harmonized`] by reference.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use ccdi_cde as cde;
-    /// use ccdi_models as models;
-    ///
-    /// use cde::parse::cde::member::Variant;
-    /// use cde::parse::cde::Entity;
-    /// use cde::parse::cde::Member;
-    /// use models::metadata::field::description::Harmonized;
-    /// use models::Url;
-    ///
-    /// let description = Harmonized::new(
-    ///     String::from("test"),
-    ///     String::from("caDSR ------ v1.00"),
-    ///     Url::try_from("https://cancer.gov").unwrap(),
-    ///     "**`A Standard`**
-    ///     
-    ///     A description for the entity.
-    ///
-    ///     Link: <https://example.com>"
-    ///         .parse::<Entity>()?,
-    ///     vec![(
-    ///         String::from("Unknown"),
-    ///         Member::Variant(
-    ///             "`Unknown`
-    ///              
-    ///             A description for the variant."
-    ///                 .parse::<Variant>()
-    ///                 .unwrap(),
-    ///         ),
-    ///     )],
-    /// );
-    ///
-    /// assert_eq!(description.entity().standard(), "A Standard");
     /// assert_eq!(
-    ///     description.entity().description(),
-    ///     "A description for the entity."
+    ///     description.wiki_url(),
+    ///     "https://github.com/CBIIT/ccdi-federation-api/wiki"
     /// );
-    /// assert_eq!(description.entity().url().as_str(), "https://example.com/");
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn entity(&self) -> &Entity {
-        &self.entity
+    pub fn wiki_url(&self) -> &str {
+        self.wiki_url.as_ref()
+    }
+
+    /// Gets the harmonization standard of the [`Harmonized`] by reference (if
+    /// it exists).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_cde as cde;
+    /// use ccdi_models as models;
+    ///
+    /// use cde::parse::cde::member::Variant;
+    /// use cde::parse::cde::Entity;
+    /// use cde::parse::cde::Member;
+    /// use models::metadata::field::description::harmonized::Kind;
+    /// use models::metadata::field::description::harmonized::Standard;
+    /// use models::metadata::field::description::Harmonized;
+    /// use models::Url;
+    ///
+    /// let description = Harmonized::new(
+    ///     Kind::Enum,
+    ///     String::from("entity"),
+    ///     String::from("A description for the entity."),
+    ///     Url::try_from("https://github.com/CBIIT/ccdi-federation-api/wiki").unwrap(),
+    ///     Some(Standard::new(
+    ///         String::from("caDSR ------ v1.00"),
+    ///         Url::try_from("https://cancer.gov").unwrap(),
+    ///     )),
+    ///     Some(vec![(
+    ///         String::from("Unknown"),
+    ///         Member::Variant(
+    ///             "`Unknown`
+    ///              
+    ///             A description for the variant."
+    ///                 .parse::<Variant>()
+    ///                 .unwrap(),
+    ///         ),
+    ///     )]),
+    /// );
+    ///
+    /// assert_eq!(description.standard().unwrap().name(), "caDSR ------ v1.00");
+    /// assert_eq!(description.standard().unwrap().url(), "https://cancer.gov/");
+    ///
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn standard(&self) -> Option<&Standard> {
+        self.standard.as_ref()
     }
 
     /// Gets the members for the [`Harmonized`] by reference.
@@ -298,20 +370,21 @@ impl Harmonized {
     /// use cde::parse::cde::member::Variant;
     /// use cde::parse::cde::Entity;
     /// use cde::parse::cde::Member;
+    /// use models::metadata::field::description::harmonized::Kind;
+    /// use models::metadata::field::description::harmonized::Standard;
     /// use models::metadata::field::description::Harmonized;
     /// use models::Url;
     ///
     /// let description = Harmonized::new(
-    ///     String::from("test"),
-    ///     String::from("caDSR ------ v1.00"),
-    ///     Url::try_from("https://cancer.gov").unwrap(),
-    ///     "**`A Standard`**
-    ///     
-    ///     A description for the entity.
-    ///
-    ///     Link: <https://example.com>"
-    ///         .parse::<Entity>()?,
-    ///     vec![(
+    ///     Kind::Enum,
+    ///     String::from("entity"),
+    ///     String::from("A description for the entity."),
+    ///     Url::try_from("https://github.com/CBIIT/ccdi-federation-api/wiki").unwrap(),
+    ///     Some(Standard::new(
+    ///         String::from("caDSR ------ v1.00"),
+    ///         Url::try_from("https://cancer.gov").unwrap(),
+    ///     )),
+    ///     Some(vec![(
     ///         String::from("Unknown"),
     ///         Member::Variant(
     ///             "`Unknown`
@@ -320,12 +393,12 @@ impl Harmonized {
     ///                 .parse::<Variant>()
     ///                 .unwrap(),
     ///         ),
-    ///     )],
+    ///     )]),
     /// );
     ///
-    /// assert_eq!(description.members().len(), 1);
+    /// assert_eq!(description.members().unwrap().len(), 1);
     ///
-    /// let (identifier, variant) = description.members().first().unwrap();
+    /// let (identifier, variant) = description.members().unwrap().first().unwrap();
     ///
     /// assert_eq!(identifier.as_str(), "Unknown");
     /// assert_eq!(
@@ -339,7 +412,7 @@ impl Harmonized {
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
-    pub fn members(&self) -> &Vec<(String, Member)> {
-        &self.members
+    pub fn members(&self) -> Option<&Vec<(String, Member)>> {
+        self.members.as_ref()
     }
 }

--- a/packages/ccdi-models/src/metadata/field/description/harmonized/sample.rs
+++ b/packages/ccdi-models/src/metadata/field/description/harmonized/sample.rs
@@ -3,8 +3,12 @@
 use ccdi_cde as cde;
 
 use cde::CDE;
+use introspect::Entity;
+use introspect::IntrospectedEntity as _;
 
 use crate::metadata::field::description;
+use crate::metadata::field::description::harmonized::Kind;
+use crate::metadata::field::description::harmonized::Standard;
 use crate::metadata::field::description::r#trait::Description as _;
 use crate::metadata::field::description::Harmonized;
 use crate::Url;
@@ -12,10 +16,31 @@ use crate::Url;
 /// Gets the harmonized fields for samples.
 pub fn get_field_descriptions() -> Vec<description::Description> {
     vec![
+        crate::sample::metadata::AgeAtDiagnosis::description(),
         cde::v1::sample::DiseasePhase::description(),
         cde::v2::sample::TissueType::description(),
         cde::v1::sample::TumorClassification::description(),
+        cde::v1::sample::TumorTissueMorphology::description(),
+        crate::sample::metadata::AgeAtCollection::description(),
     ]
+}
+
+impl description::r#trait::Description for crate::sample::metadata::AgeAtDiagnosis {
+    fn description() -> description::Description {
+        let description = match Self::introspected_entity() {
+            Entity::Enum(entity) => entity.documentation().unwrap().to_string(),
+            Entity::Struct(entity) => entity.documentation().unwrap().to_string(),
+        };
+
+        description::Description::Harmonized(Harmonized::new(
+            Kind::Struct,
+            String::from("age_at_diagnosis"),
+            description,
+            Url::try_from("https://github.com/CBIIT/ccdi-federation-api/wiki/Subject-Metadata-Fields#age_at_diagnosis").unwrap(),
+            None,
+            None,
+        ))
+    }
 }
 
 impl description::r#trait::Description for cde::v1::sample::DiseasePhase {
@@ -26,11 +51,12 @@ impl description::r#trait::Description for cde::v1::sample::DiseasePhase {
         let members = Self::members().unwrap();
 
         description::Description::Harmonized(Harmonized::new(
+            Kind::Enum,
             String::from("disease_phase"),
-            entity.standard().to_string(),
-            Url::from(entity.url().clone()),
-            entity,
-            members,
+            entity.description().to_string(),
+            Url::try_from("https://github.com/CBIIT/ccdi-federation-api/wiki/Sample-Metadata-Fields#disease_phase").unwrap(),
+            Some(Standard::new(entity.standard_name().to_string(), crate::Url::from(entity.standard_url().clone()))),
+            Some(members),
         ))
     }
 }
@@ -43,11 +69,12 @@ impl description::r#trait::Description for cde::v2::sample::TissueType {
         let members = Self::members().unwrap();
 
         description::Description::Harmonized(Harmonized::new(
+            Kind::Enum,
             String::from("tissue_type"),
-            entity.standard().to_string(),
-            Url::from(entity.url().clone()),
-            entity,
-            members,
+            entity.description().to_string(),
+            Url::try_from("https://github.com/CBIIT/ccdi-federation-api/wiki/Sample-Metadata-Fields#tissue_type").unwrap(),
+            Some(Standard::new(entity.standard_name().to_string(), crate::Url::from(entity.standard_url().clone()))),
+            Some(members),
         ))
     }
 }
@@ -60,11 +87,48 @@ impl description::r#trait::Description for cde::v1::sample::TumorClassification 
         let members = Self::members().unwrap();
 
         description::Description::Harmonized(Harmonized::new(
+            Kind::Enum,
             String::from("tumor_classification"),
-            entity.standard().to_string(),
-            Url::from(entity.url().clone()),
-            entity,
-            members,
+            entity.description().to_string(),
+            Url::try_from("https://github.com/CBIIT/ccdi-federation-api/wiki/Sample-Metadata-Fields#tumor_classification").unwrap(),
+            Some(Standard::new(entity.standard_name().to_string(), crate::Url::from(entity.standard_url().clone()))),
+            Some(members),
+        ))
+    }
+}
+
+impl description::r#trait::Description for cde::v1::sample::TumorTissueMorphology {
+    fn description() -> description::Description {
+        // SAFETY: these two unwraps are tested statically below in the test
+        // that constructs the description using `get_fields()`.
+        let entity = Self::entity().unwrap();
+        let members = Self::members().unwrap();
+
+        description::Description::Harmonized(Harmonized::new(
+            Kind::Enum,
+            String::from("tumor_tissue_morphology"),
+            entity.description().to_string(),
+            Url::try_from("https://github.com/CBIIT/ccdi-federation-api/wiki/Sample-Metadata-Fields#tumor_tissue_morphology").unwrap(),
+            Some(Standard::new(entity.standard_name().to_string(), crate::Url::from(entity.standard_url().clone()))),
+            Some(members),
+        ))
+    }
+}
+
+impl description::r#trait::Description for crate::sample::metadata::AgeAtCollection {
+    fn description() -> description::Description {
+        let description = match Self::introspected_entity() {
+            Entity::Enum(entity) => entity.documentation().unwrap().to_string(),
+            Entity::Struct(entity) => entity.documentation().unwrap().to_string(),
+        };
+
+        description::Description::Harmonized(Harmonized::new(
+            Kind::Struct,
+            String::from("age_at_collection"),
+            description,
+            Url::try_from("https://github.com/CBIIT/ccdi-federation-api/wiki/Sample-Metadata-Fields#age_at_collection").unwrap(),
+            None,
+            None,
         ))
     }
 }

--- a/packages/ccdi-models/src/metadata/field/description/harmonized/standard.rs
+++ b/packages/ccdi-models/src/metadata/field/description/harmonized/standard.rs
@@ -1,0 +1,83 @@
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use crate::Url;
+
+/// A standard to which a field is harmonized.
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
+#[schema(as = models::metadata::field::description::harmonized::Standard)]
+pub struct Standard {
+    /// The name.
+    name: String,
+
+    /// A link that describes the standard.
+    #[schema(value_type = models::Url)]
+    url: Url,
+}
+
+impl Standard {
+    /// Creates a new [`Standard`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_models as models;
+    ///
+    /// use models::metadata::field::description::harmonized::Standard;
+    /// use models::Url;
+    ///
+    /// let standard = Standard::new(
+    ///     String::from("caDSR CDE ------- v1.00"),
+    ///     Url::try_from("https://cancer.gov").unwrap(),
+    /// );
+    ///
+    /// assert_eq!(standard.name(), "caDSR CDE ------- v1.00");
+    /// assert_eq!(standard.url(), "https://cancer.gov/");
+    /// ```
+    pub fn new(name: String, url: Url) -> Self {
+        Self { name, url }
+    }
+
+    /// Gets the name of the [`Standard`] by reference.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_models as models;
+    ///
+    /// use models::metadata::field::description::harmonized::Standard;
+    /// use models::Url;
+    ///
+    /// let standard = Standard::new(
+    ///     String::from("caDSR CDE ------- v1.00"),
+    ///     Url::try_from("https://cancer.gov").unwrap(),
+    /// );
+    ///
+    /// assert_eq!(standard.name(), "caDSR CDE ------- v1.00");
+    /// ```
+    pub fn name(&self) -> &str {
+        self.name.as_ref()
+    }
+
+    /// Gets the URL that describes the [`Standard`] by reference.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_models as models;
+    ///
+    /// use models::metadata::field::description::harmonized::Standard;
+    /// use models::Url;
+    ///
+    /// let standard = Standard::new(
+    ///     String::from("caDSR CDE ------- v1.00"),
+    ///     Url::try_from("https://cancer.gov").unwrap(),
+    /// );
+    ///
+    /// assert_eq!(standard.url(), "https://cancer.gov/");
+    /// ```
+    pub fn url(&self) -> &str {
+        self.url.as_ref()
+    }
+}

--- a/packages/ccdi-models/src/metadata/field/description/harmonized/subject.rs
+++ b/packages/ccdi-models/src/metadata/field/description/harmonized/subject.rs
@@ -3,10 +3,14 @@
 use ccdi_cde as cde;
 
 use cde::CDE;
+use introspect::Entity;
+use introspect::IntrospectedEntity as _;
 
 use crate::metadata::field::description;
 use crate::Url;
 
+use crate::metadata::field::description::harmonized::Kind;
+use crate::metadata::field::description::harmonized::Standard;
 use crate::metadata::field::description::r#trait::Description;
 use crate::metadata::field::description::Harmonized;
 
@@ -17,6 +21,7 @@ pub fn get_field_descriptions() -> Vec<description::Description> {
         cde::v1::subject::Race::description(),
         cde::v2::subject::Ethnicity::description(),
         cde::v1::subject::Identifier::description(),
+        cde::v1::subject::VitalStatus::description(),
     ]
 }
 
@@ -28,11 +33,18 @@ impl Description for cde::v1::subject::Sex {
         let members = Self::members().unwrap();
 
         description::Description::Harmonized(Harmonized::new(
+            Kind::Enum,
             String::from("sex"),
-            entity.standard().to_string(),
-            Url::from(entity.url().clone()),
-            entity,
-            members,
+            entity.description().to_string(),
+            Url::try_from(
+                "https://github.com/CBIIT/ccdi-federation-api/wiki/Subject-Metadata-Fields#sex",
+            )
+            .unwrap(),
+            Some(Standard::new(
+                entity.standard_name().to_string(),
+                crate::Url::from(entity.standard_url().clone()),
+            )),
+            Some(members),
         ))
     }
 }
@@ -45,11 +57,18 @@ impl Description for cde::v1::subject::Race {
         let members = Self::members().unwrap();
 
         description::Description::Harmonized(Harmonized::new(
+            Kind::Enum,
             String::from("race"),
-            entity.standard().to_string(),
-            Url::from(entity.url().clone()),
-            entity,
-            members,
+            entity.description().to_string(),
+            Url::try_from(
+                "https://github.com/CBIIT/ccdi-federation-api/wiki/Subject-Metadata-Fields#race",
+            )
+            .unwrap(),
+            Some(Standard::new(
+                entity.standard_name().to_string(),
+                crate::Url::from(entity.standard_url().clone()),
+            )),
+            Some(members),
         ))
     }
 }
@@ -62,11 +81,12 @@ impl Description for cde::v2::subject::Ethnicity {
         let members = Self::members().unwrap();
 
         description::Description::Harmonized(Harmonized::new(
+            Kind::Enum,
             String::from("ethnicity"),
-            entity.standard().to_string(),
-            Url::from(entity.url().clone()),
-            entity,
-            members,
+            entity.description().to_string(),
+            Url::try_from("https://github.com/CBIIT/ccdi-federation-api/wiki/Subject-Metadata-Fields#ethnicity").unwrap(),
+            Some(Standard::new(entity.standard_name().to_string(), crate::Url::from(entity.standard_url().clone()))),
+            Some(members),
         ))
     }
 }
@@ -79,11 +99,48 @@ impl Description for cde::v1::subject::Identifier {
         let members = Self::members().unwrap();
 
         description::Description::Harmonized(Harmonized::new(
+            Kind::Struct,
             String::from("identifiers"),
-            entity.standard().to_string(),
-            Url::from(entity.url().clone()),
-            entity,
-            members,
+            entity.description().to_string(),
+            Url::try_from("https://github.com/CBIIT/ccdi-federation-api/wiki/Subject-Metadata-Fields#identifiers").unwrap(),
+            Some(Standard::new(entity.standard_name().to_string(), crate::Url::from(entity.standard_url().clone()))),
+            Some(members),
+        ))
+    }
+}
+
+impl Description for cde::v1::subject::VitalStatus {
+    fn description() -> description::Description {
+        // SAFETY: these two unwraps are tested statically below in the test
+        // that constructs the description using `get_fields()`.
+        let entity = Self::entity().unwrap();
+        let members = Self::members().unwrap();
+
+        description::Description::Harmonized(Harmonized::new(
+            Kind::Enum,
+            String::from("vital_status"),
+            entity.description().to_string(),
+            Url::try_from("https://github.com/CBIIT/ccdi-federation-api/wiki/Subject-Metadata-Fields#vital_status").unwrap(),
+            Some(Standard::new(entity.standard_name().to_string(), crate::Url::from(entity.standard_url().clone()))),
+            Some(members),
+        ))
+    }
+}
+
+impl description::r#trait::Description for crate::subject::metadata::AgeAtVitalStatus {
+    fn description() -> description::Description {
+        let description = match Self::introspected_entity() {
+            Entity::Enum(entity) => entity.documentation().unwrap().to_string(),
+            Entity::Struct(entity) => entity.documentation().unwrap().to_string(),
+        };
+
+        description::Description::Harmonized(Harmonized::new(
+            Kind::Struct,
+            String::from("age_at_vital_status"),
+            description,
+            Url::try_from("https://github.com/CBIIT/ccdi-federation-api/wiki/Subject-Metadata-Fields#age_at_vital_status").unwrap(),
+            None,
+            None,
         ))
     }
 }

--- a/packages/ccdi-models/src/metadata/field/unowned.rs
+++ b/packages/ccdi-models/src/metadata/field/unowned.rs
@@ -15,12 +15,13 @@ use utoipa::ToSchema;
 
 #[macropol::macropol]
 macro_rules! unowned_field {
-    ($name: ident, $as: ty, $inner: ty, $value: expr, $import: expr) => {
+    ($name: ident, $as: ty, $inner: ty, $inner_as: ty, $value: expr, $import: expr) => {
         #[derive(Clone, Debug, Deserialize, Eq, Serialize, PartialEq, ToSchema)]
         #[schema(as = $as)]
         /// An unowned field representing a [`${stringify!($name)}`].
         pub struct $name {
             /// The value of the metadata field.
+            #[schema(value_type = $inner_as)]
             value: $inner,
 
             /// The ancestors from which this field was derived.
@@ -155,6 +156,7 @@ unowned_field!(
     Field,
     field::unowned::Field,
     Value,
+    Value,
     Value::Null,
     serde_json::Value
 );
@@ -165,8 +167,27 @@ pub mod sample {
     use ccdi_cde as cde;
 
     unowned_field!(
+        AgeAtDiagnosis,
+        field::unowned::sample::AgeAtDiagnosis,
+        crate::sample::metadata::AgeAtDiagnosis,
+        models::sample::metadata::AgeAtDiagnosis,
+        models::sample::metadata::AgeAtDiagnosis::from(OrderedFloat(365.25)),
+        ordered_float::OrderedFloat
+    );
+
+    unowned_field!(
+        AgeAtCollection,
+        field::unowned::sample::AgeAtCollection,
+        crate::sample::metadata::AgeAtCollection,
+        models::sample::metadata::AgeAtCollection,
+        models::sample::metadata::AgeAtCollection::from(OrderedFloat(365.25)),
+        ordered_float::OrderedFloat
+    );
+
+    unowned_field!(
         DiseasePhase,
         field::unowned::sample::DiseasePhase,
+        cde::v1::sample::DiseasePhase,
         cde::v1::sample::DiseasePhase,
         cde::v1::sample::DiseasePhase::InitialDiagnosis,
         ccdi_cde as cde
@@ -176,6 +197,7 @@ pub mod sample {
         TissueType,
         field::unowned::sample::TissueType,
         cde::v2::sample::TissueType,
+        cde::v2::sample::TissueType,
         cde::v2::sample::TissueType::Tumor,
         ccdi_cde as cde
     );
@@ -184,7 +206,17 @@ pub mod sample {
         TumorClassification,
         field::unowned::sample::TumorClassification,
         cde::v1::sample::TumorClassification,
+        cde::v1::sample::TumorClassification,
         cde::v1::sample::TumorClassification::Primary,
+        ccdi_cde as cde
+    );
+
+    unowned_field!(
+        TumorTissueMorphology,
+        field::unowned::sample::TumorTissueMorphology,
+        cde::v1::sample::TumorTissueMorphology,
+        cde::v1::sample::TumorTissueMorphology,
+        cde::v1::sample::TumorTissueMorphology::from(String::from("8010/0")),
         ccdi_cde as cde
     );
 }
@@ -198,6 +230,7 @@ pub mod subject {
         Sex,
         field::unowned::subject::Sex,
         cde::v1::subject::Sex,
+        cde::v1::subject::Sex,
         cde::v1::subject::Sex::Unknown,
         ccdi_cde as cde
     );
@@ -205,6 +238,7 @@ pub mod subject {
     unowned_field!(
         Race,
         field::unowned::subject::Race,
+        cde::v1::subject::Race,
         cde::v1::subject::Race,
         cde::v1::subject::Race::Unknown,
         ccdi_cde as cde
@@ -214,7 +248,26 @@ pub mod subject {
         Ethnicity,
         field::unowned::subject::Ethnicity,
         cde::v2::subject::Ethnicity,
+        cde::v2::subject::Ethnicity,
         cde::v2::subject::Ethnicity::Unknown,
+        ccdi_cde as cde
+    );
+
+    unowned_field!(
+        AgeAtVitalStatus,
+        field::unowned::subject::AgeAtVitalStatus,
+        crate::subject::metadata::AgeAtVitalStatus,
+        models::subject::metadata::AgeAtVitalStatus,
+        models::subject::metadata::AgeAtVitalStatus::from(OrderedFloat(365.25)),
+        ordered_float::OrderedFloat
+    );
+
+    unowned_field!(
+        VitalStatus,
+        field::unowned::subject::VitalStatus,
+        cde::v1::subject::VitalStatus,
+        cde::v1::subject::VitalStatus,
+        cde::v1::subject::VitalStatus::Unknown,
         ccdi_cde as cde
     );
 }

--- a/packages/ccdi-models/src/sample/metadata.rs
+++ b/packages/ccdi-models/src/sample/metadata.rs
@@ -1,5 +1,6 @@
 //! Metadata for a [`Sample`](super::Sample).
 
+use ordered_float::OrderedFloat;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -7,14 +8,22 @@ use utoipa::ToSchema;
 use crate::metadata::field;
 use crate::metadata::fields;
 
+mod age_at_collection;
+mod age_at_diagnosis;
 pub mod builder;
 
+pub use age_at_collection::AgeAtCollection;
+pub use age_at_diagnosis::AgeAtDiagnosis;
 pub use builder::Builder;
 
 /// Metadata associated with a sample.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema)]
 #[schema(as = models::sample::Metadata)]
 pub struct Metadata {
+    /// The approximate age at diagnosis.
+    #[schema(value_type = field::unowned::sample::AgeAtDiagnosis, nullable = true)]
+    age_at_diagnosis: Option<field::unowned::sample::AgeAtDiagnosis>,
+
     /// The phase of the disease when this sample was acquired.
     #[schema(value_type = field::unowned::sample::DiseasePhase, nullable = true)]
     disease_phase: Option<field::unowned::sample::DiseasePhase>,
@@ -28,6 +37,14 @@ pub struct Metadata {
     #[schema(value_type = field::unowned::sample::TumorClassification, nullable = true)]
     tumor_classification: Option<field::unowned::sample::TumorClassification>,
 
+    /// The ICD-O-3 morphology code for the tumor tissue.
+    #[schema(value_type = field::unowned::sample::TumorTissueMorphology, nullable = true)]
+    tumor_tissue_morphology: Option<field::unowned::sample::TumorTissueMorphology>,
+
+    /// The approximate age at collection.
+    #[schema(value_type = field::unowned::sample::AgeAtCollection, nullable = true)]
+    age_at_collection: Option<field::unowned::sample::AgeAtCollection>,
+
     /// An unharmonized map of metadata fields.
     #[schema(value_type = fields::Unharmonized)]
     #[serde(skip_serializing_if = "fields::Unharmonized::is_empty")]
@@ -35,6 +52,38 @@ pub struct Metadata {
 }
 
 impl Metadata {
+    /// Gets the approximate age at diagnosis for the [`Metadata`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_models as models;
+    /// use ordered_float::OrderedFloat;
+    ///
+    /// use models::metadata::field::unowned::sample::AgeAtDiagnosis;
+    /// use models::sample::metadata::Builder;
+    ///
+    /// let metadata = Builder::default()
+    ///     .age_at_diagnosis(AgeAtDiagnosis::new(
+    ///         models::sample::metadata::AgeAtDiagnosis::from(OrderedFloat(365.25)),
+    ///         None,
+    ///         None,
+    ///     ))
+    ///     .build();
+    ///
+    /// assert_eq!(
+    ///     metadata.age_at_diagnosis(),
+    ///     Some(&AgeAtDiagnosis::new(
+    ///         models::sample::metadata::AgeAtDiagnosis::from(OrderedFloat(365.25)),
+    ///         None,
+    ///         None
+    ///     ))
+    /// );
+    /// ```
+    pub fn age_at_diagnosis(&self) -> Option<&field::unowned::sample::AgeAtDiagnosis> {
+        self.age_at_diagnosis.as_ref()
+    }
+
     /// Gets the harmonized disease phase for the [`Metadata`].
     ///
     /// # Examples
@@ -131,6 +180,72 @@ impl Metadata {
         self.tumor_classification.as_ref()
     }
 
+    /// Gets the harmonized tumor tissue morphology code for the [`Metadata`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_cde as cde;
+    /// use ccdi_models as models;
+    ///
+    /// use models::metadata::field::unowned::sample::TumorTissueMorphology;
+    /// use models::sample::metadata::Builder;
+    ///
+    /// let metadata = Builder::default()
+    ///     .tumor_tissue_morphology(TumorTissueMorphology::new(
+    ///         cde::v1::sample::TumorTissueMorphology::from(String::from("8010/0")),
+    ///         None,
+    ///         None,
+    ///     ))
+    ///     .build();
+    ///
+    /// assert_eq!(
+    ///     metadata.tumor_tissue_morphology(),
+    ///     Some(&TumorTissueMorphology::new(
+    ///         cde::v1::sample::TumorTissueMorphology::from(String::from("8010/0")),
+    ///         None,
+    ///         None
+    ///     ))
+    /// );
+    /// ```
+    pub fn tumor_tissue_morphology(
+        &self,
+    ) -> Option<&field::unowned::sample::TumorTissueMorphology> {
+        self.tumor_tissue_morphology.as_ref()
+    }
+
+    /// Gets the approximate age at collection for the [`Metadata`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_models as models;
+    /// use ordered_float::OrderedFloat;
+    ///
+    /// use models::metadata::field::unowned::sample::AgeAtCollection;
+    /// use models::sample::metadata::Builder;
+    ///
+    /// let metadata = Builder::default()
+    ///     .age_at_collection(AgeAtCollection::new(
+    ///         models::sample::metadata::AgeAtCollection::from(OrderedFloat(365.25)),
+    ///         None,
+    ///         None,
+    ///     ))
+    ///     .build();
+    ///
+    /// assert_eq!(
+    ///     metadata.age_at_collection(),
+    ///     Some(&AgeAtCollection::new(
+    ///         models::sample::metadata::AgeAtCollection::from(OrderedFloat(365.25)),
+    ///         None,
+    ///         None
+    ///     ))
+    /// );
+    /// ```
+    pub fn age_at_collection(&self) -> Option<&field::unowned::sample::AgeAtCollection> {
+        self.age_at_collection.as_ref()
+    }
+
     /// Gets the unharmonized fields for the [`Metadata`].
     ///
     /// # Examples
@@ -194,9 +309,25 @@ impl Metadata {
     /// ```
     pub fn random() -> Metadata {
         Metadata {
+            age_at_diagnosis: Some(field::unowned::sample::AgeAtDiagnosis::new(
+                crate::sample::metadata::AgeAtDiagnosis::from(OrderedFloat(365.25)),
+                None,
+                None,
+            )),
             disease_phase: rand::random(),
             tissue_type: rand::random(),
             tumor_classification: rand::random(),
+            tumor_tissue_morphology: Some(field::unowned::sample::TumorTissueMorphology::new(
+                // "8000/0" is the ICD-O-3 code for a "Neoplasm".
+                ccdi_cde::v1::sample::TumorTissueMorphology::from(String::from("8000/0")),
+                None,
+                None,
+            )),
+            age_at_collection: Some(field::unowned::sample::AgeAtCollection::new(
+                crate::sample::metadata::AgeAtCollection::from(OrderedFloat(365.25)),
+                None,
+                None,
+            )),
             unharmonized: Default::default(),
         }
     }
@@ -211,7 +342,7 @@ mod tests {
         let metadata = builder::Builder::default().build();
         assert_eq!(
             &serde_json::to_string(&metadata).unwrap(),
-            "{\"disease_phase\":null,\"tissue_type\":null,\"tumor_classification\":null}"
+            "{\"age_at_diagnosis\":null,\"disease_phase\":null,\"tissue_type\":null,\"tumor_classification\":null,\"tumor_tissue_morphology\":null,\"age_at_collection\":null}"
         );
     }
 }

--- a/packages/ccdi-models/src/sample/metadata/age_at_collection.rs
+++ b/packages/ccdi-models/src/sample/metadata/age_at_collection.rs
@@ -1,0 +1,30 @@
+use introspect::Introspect;
+use ordered_float::OrderedFloat;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// The approximate age of collection in days.
+///
+/// * When the age at collection is collected by the source server in days, the
+///   number of days is reported directly.
+/// * When the age at collection is collected by the source server in years, the
+///   number of years is multiplied by 365.25 to arrive at an approximate number
+///   of days.
+#[derive(
+    Clone, Debug, Deserialize, Eq, Introspect, Ord, PartialEq, PartialOrd, Serialize, ToSchema,
+)]
+#[schema(as = models::sample::metadata::AgeAtCollection, value_type = f32)]
+pub struct AgeAtCollection(OrderedFloat<f32>);
+
+impl From<OrderedFloat<f32>> for AgeAtCollection {
+    fn from(value: OrderedFloat<f32>) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for AgeAtCollection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/packages/ccdi-models/src/sample/metadata/age_at_diagnosis.rs
+++ b/packages/ccdi-models/src/sample/metadata/age_at_diagnosis.rs
@@ -1,0 +1,30 @@
+use introspect::Introspect;
+use ordered_float::OrderedFloat;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// The approximate age of diagnosis in days.
+///
+/// * When the age at diagnosis is collected by the source server in days, the
+///   number of days is reported directly.
+/// * When the age at diagnosis is collected by the source server in years, the
+///   number of years is multiplied by 365.25 to arrive at an approximate number
+///   of days.
+#[derive(
+    Clone, Debug, Deserialize, Eq, Introspect, Ord, PartialEq, PartialOrd, Serialize, ToSchema,
+)]
+#[schema(as = models::sample::metadata::AgeAtDiagnosis, value_type = f32)]
+pub struct AgeAtDiagnosis(OrderedFloat<f32>);
+
+impl From<OrderedFloat<f32>> for AgeAtDiagnosis {
+    fn from(value: OrderedFloat<f32>) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for AgeAtDiagnosis {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/packages/ccdi-models/src/sample/metadata/builder.rs
+++ b/packages/ccdi-models/src/sample/metadata/builder.rs
@@ -7,6 +7,9 @@ use crate::sample::Metadata;
 /// A builder for [`Metadata`].
 #[derive(Clone, Debug, Default)]
 pub struct Builder {
+    /// The approximate age at diagnosis.
+    age_at_diagnosis: Option<field::unowned::sample::AgeAtDiagnosis>,
+
     /// The phase of the disease when this sample was acquired.
     disease_phase: Option<field::unowned::sample::DiseasePhase>,
 
@@ -17,11 +20,40 @@ pub struct Builder {
     /// characteristics.
     tumor_classification: Option<field::unowned::sample::TumorClassification>,
 
+    /// The ICD-O-3 morphology code for the tumor tissue.
+    tumor_tissue_morphology: Option<field::unowned::sample::TumorTissueMorphology>,
+
+    /// The approximate age at collection.
+    age_at_collection: Option<field::unowned::sample::AgeAtCollection>,
+
     /// An unharmonized map of metadata fields.
     unharmonized: fields::Unharmonized,
 }
 
 impl Builder {
+    /// Sets the `age_at_diagnosis` field of the [`Builder`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_models as models;
+    /// use ordered_float::OrderedFloat;
+    ///
+    /// use models::metadata::field::unowned::sample::AgeAtDiagnosis;
+    /// use models::sample::metadata::Builder;
+    ///
+    /// let field = AgeAtDiagnosis::new(
+    ///     models::sample::metadata::AgeAtDiagnosis::from(OrderedFloat(365.25)),
+    ///     None,
+    ///     None,
+    /// );
+    /// let builder = Builder::default().age_at_diagnosis(field);
+    /// ```
+    pub fn age_at_diagnosis(mut self, field: field::unowned::sample::AgeAtDiagnosis) -> Self {
+        self.age_at_diagnosis = Some(field);
+        self
+    }
+
     /// Sets the `disease_phase` field of the [`Builder`].
     ///
     /// # Examples
@@ -79,6 +111,55 @@ impl Builder {
         field: field::unowned::sample::TumorClassification,
     ) -> Self {
         self.tumor_classification = Some(field);
+        self
+    }
+
+    /// Sets the `tumor_tissue_morphology` field of the [`Builder`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_cde as cde;
+    /// use ccdi_models as models;
+    ///
+    /// use models::metadata::field::unowned::sample::TumorTissueMorphology;
+    /// use models::sample::metadata::Builder;
+    ///
+    /// let field = TumorTissueMorphology::new(
+    ///     cde::v1::sample::TumorTissueMorphology::from(String::from("8010/0")),
+    ///     None,
+    ///     None,
+    /// );
+    /// let builder = Builder::default().tumor_tissue_morphology(field);
+    /// ```
+    pub fn tumor_tissue_morphology(
+        mut self,
+        field: field::unowned::sample::TumorTissueMorphology,
+    ) -> Self {
+        self.tumor_tissue_morphology = Some(field);
+        self
+    }
+
+    /// Sets the `age_at_collection` field of the [`Builder`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_models as models;
+    /// use ordered_float::OrderedFloat;
+    ///
+    /// use models::metadata::field::unowned::sample::AgeAtCollection;
+    /// use models::sample::metadata::Builder;
+    ///
+    /// let field = AgeAtCollection::new(
+    ///     models::sample::metadata::AgeAtCollection::from(OrderedFloat(365.25)),
+    ///     None,
+    ///     None,
+    /// );
+    /// let builder = Builder::default().age_at_collection(field);
+    /// ```
+    pub fn age_at_collection(mut self, field: field::unowned::sample::AgeAtCollection) -> Self {
+        self.age_at_collection = Some(field);
         self
     }
 
@@ -147,9 +228,12 @@ impl Builder {
     /// ```
     pub fn build(self) -> Metadata {
         Metadata {
+            age_at_diagnosis: self.age_at_diagnosis,
+            age_at_collection: self.age_at_collection,
             disease_phase: self.disease_phase,
             tissue_type: self.tissue_type,
             tumor_classification: self.tumor_classification,
+            tumor_tissue_morphology: self.tumor_tissue_morphology,
             unharmonized: self.unharmonized,
         }
     }

--- a/packages/ccdi-models/src/subject/metadata.rs
+++ b/packages/ccdi-models/src/subject/metadata.rs
@@ -1,5 +1,6 @@
 //! Metadata for a [`Subject`](super::Subject).
 
+use ordered_float::OrderedFloat;
 use serde::Deserialize;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -8,8 +9,10 @@ use crate::metadata::field;
 use crate::metadata::fields;
 use crate::subject::Identifier;
 
-pub mod builder;
+mod age_at_vital_status;
+mod builder;
 
+pub use age_at_vital_status::AgeAtVitalStatus;
 pub use builder::Builder;
 
 /// Metadata associated with a subject.
@@ -34,6 +37,14 @@ pub struct Metadata {
     /// for the [`Subject`].
     #[schema(value_type = Vec<field::owned::subject::Identifier>, nullable = true)]
     identifiers: Option<Vec<field::owned::subject::Identifier>>,
+
+    /// The vital status of the subject.
+    #[schema(value_type = field::unowned::subject::VitalStatus, nullable = true)]
+    vital_status: Option<field::unowned::subject::VitalStatus>,
+
+    /// The approximate age at vital status.
+    #[schema(value_type = field::unowned::subject::AgeAtVitalStatus, nullable = true)]
+    age_at_vital_status: Option<field::unowned::subject::AgeAtVitalStatus>,
 
     /// An unharmonized map of metadata fields.
     #[schema(value_type = fields::Unharmonized)]
@@ -156,6 +167,70 @@ impl Metadata {
         self.identifiers.as_ref()
     }
 
+    /// Gets the approximate age at vital status for the [`Metadata`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_models as models;
+    /// use ordered_float::OrderedFloat;
+    ///
+    /// use models::metadata::field::unowned::subject::AgeAtVitalStatus;
+    /// use models::subject::metadata::Builder;
+    ///
+    /// let metadata = Builder::default()
+    ///     .age_at_vital_status(AgeAtVitalStatus::new(
+    ///         models::subject::metadata::AgeAtVitalStatus::from(OrderedFloat(365.25)),
+    ///         None,
+    ///         None,
+    ///     ))
+    ///     .build();
+    ///
+    /// assert_eq!(
+    ///     metadata.age_at_vital_status(),
+    ///     Some(&AgeAtVitalStatus::new(
+    ///         models::subject::metadata::AgeAtVitalStatus::from(OrderedFloat(365.25)),
+    ///         None,
+    ///         None
+    ///     ))
+    /// );
+    /// ```
+    pub fn age_at_vital_status(&self) -> Option<&field::unowned::subject::AgeAtVitalStatus> {
+        self.age_at_vital_status.as_ref()
+    }
+
+    /// Gets the vital status for the [`Metadata`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_cde as cde;
+    /// use ccdi_models as models;
+    ///
+    /// use models::metadata::field::unowned::subject::VitalStatus;
+    /// use models::subject::metadata::Builder;
+    ///
+    /// let metadata = Builder::default()
+    ///     .vital_status(VitalStatus::new(
+    ///         cde::v1::subject::VitalStatus::Unknown,
+    ///         None,
+    ///         None,
+    ///     ))
+    ///     .build();
+    ///
+    /// assert_eq!(
+    ///     metadata.vital_status(),
+    ///     Some(&VitalStatus::new(
+    ///         cde::v1::subject::VitalStatus::Unknown,
+    ///         None,
+    ///         None
+    ///     ))
+    /// );
+    /// ```
+    pub fn vital_status(&self) -> Option<&field::unowned::subject::VitalStatus> {
+        self.vital_status.as_ref()
+    }
+
     /// Gets the unharmonized fields for the [`Metadata`].
     ///
     /// # Examples
@@ -241,6 +316,12 @@ impl Metadata {
                 None,
                 Some(true),
             )]),
+            vital_status: Some(rand::random()),
+            age_at_vital_status: Some(field::unowned::subject::AgeAtVitalStatus::new(
+                crate::subject::metadata::AgeAtVitalStatus::from(OrderedFloat(365.25)),
+                None,
+                None,
+            )),
             unharmonized: Default::default(),
         }
     }
@@ -255,7 +336,7 @@ mod tests {
         let metadata = builder::Builder::default().build();
         assert_eq!(
             &serde_json::to_string(&metadata).unwrap(),
-            "{\"sex\":null,\"race\":null,\"ethnicity\":null,\"identifiers\":null}"
+            "{\"sex\":null,\"race\":null,\"ethnicity\":null,\"identifiers\":null,\"vital_status\":null,\"age_at_vital_status\":null}"
         );
     }
 }

--- a/packages/ccdi-models/src/subject/metadata/age_at_vital_status.rs
+++ b/packages/ccdi-models/src/subject/metadata/age_at_vital_status.rs
@@ -1,0 +1,30 @@
+use introspect::Introspect;
+use ordered_float::OrderedFloat;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// The approximate age at vital status in days.
+///
+/// * When the age at vital status is collected by the source server in days,
+///   the number of days is reported directly.
+/// * When the age at vital status is collected by the source server in years,
+///   the number of years is multiplied by 365.25 to arrive at an approximate
+///   number of days.
+#[derive(
+    Clone, Debug, Deserialize, Eq, Introspect, Ord, PartialEq, PartialOrd, Serialize, ToSchema,
+)]
+#[schema(as = models::subject::metadata::AgeAtVitalStatus, value_type = f32)]
+pub struct AgeAtVitalStatus(OrderedFloat<f32>);
+
+impl From<OrderedFloat<f32>> for AgeAtVitalStatus {
+    fn from(value: OrderedFloat<f32>) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for AgeAtVitalStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/packages/ccdi-models/src/subject/metadata/builder.rs
+++ b/packages/ccdi-models/src/subject/metadata/builder.rs
@@ -19,6 +19,12 @@ pub struct Builder {
     /// The identifiers for the subject.
     identifiers: Option<Vec<field::owned::subject::Identifier>>,
 
+    /// The vital status for the subject.
+    vital_status: Option<field::unowned::subject::VitalStatus>,
+
+    /// The approximate age at vital status.
+    age_at_vital_status: Option<field::unowned::subject::AgeAtVitalStatus>,
+
     /// An unharmonized map of metadata fields.
     unharmonized: fields::Unharmonized,
 }
@@ -116,6 +122,51 @@ impl Builder {
         self
     }
 
+    /// Sets the `vital_status` field of the [`Builder`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_cde as cde;
+    /// use ccdi_models as models;
+    ///
+    /// use models::metadata::field::unowned::subject::VitalStatus;
+    /// use models::subject::metadata::Builder;
+    ///
+    /// let field = VitalStatus::new(cde::v1::subject::VitalStatus::Unknown, None, None);
+    /// let builder = Builder::default().vital_status(field);
+    /// ```
+    pub fn vital_status(mut self, vital_status: field::unowned::subject::VitalStatus) -> Self {
+        self.vital_status = Some(vital_status);
+        self
+    }
+
+    /// Sets the `age_at_vital_status` field of the [`Builder`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_models as models;
+    /// use ordered_float::OrderedFloat;
+    ///
+    /// use models::metadata::field::unowned::subject::AgeAtVitalStatus;
+    /// use models::subject::metadata::Builder;
+    ///
+    /// let field = AgeAtVitalStatus::new(
+    ///     models::subject::metadata::AgeAtVitalStatus::from(OrderedFloat(365.25)),
+    ///     None,
+    ///     None,
+    /// );
+    /// let builder = Builder::default().age_at_vital_status(field);
+    /// ```
+    pub fn age_at_vital_status(
+        mut self,
+        age_at_vital_status: field::unowned::subject::AgeAtVitalStatus,
+    ) -> Self {
+        self.age_at_vital_status = Some(age_at_vital_status);
+        self
+    }
+
     /// Inserts an [`UnharmonizedField`](field::UnharmonizedField) into the
     /// `unharmonized` map.
     ///
@@ -185,6 +236,8 @@ impl Builder {
             race: self.race,
             ethnicity: self.ethnicity,
             identifiers: self.identifiers,
+            vital_status: self.vital_status,
+            age_at_vital_status: self.age_at_vital_status,
             unharmonized: self.unharmonized,
         }
     }

--- a/packages/ccdi-openapi/src/api.rs
+++ b/packages/ccdi-openapi/src/api.rs
@@ -186,27 +186,37 @@ that some fields have been left out of the definitions for brevity.
         server::routes::info::info_index,
     ),
     components(schemas(
-        // Subject common data elements (CDEs).
+        // Harmonized subject metadata elements.
         cde::v1::subject::Race,
         cde::v1::subject::Sex,
         cde::v2::subject::Ethnicity,
         cde::v1::subject::Identifier,
+        cde::v1::subject::VitalStatus,
+        models::subject::metadata::AgeAtVitalStatus,
 
-        // Sample common data elements (CDEs).
+        // Harmonized sample metadata elements.
+        models::sample::metadata::AgeAtDiagnosis,
         cde::v1::sample::DiseasePhase,
         cde::v2::sample::TissueType,
         cde::v1::sample::TumorClassification,
+        cde::v1::sample::TumorTissueMorphology,
+        models::sample::metadata::AgeAtCollection,
 
         // Harmonized subject fields.
         field::unowned::subject::Sex,
         field::unowned::subject::Race,
         field::unowned::subject::Ethnicity,
         field::owned::subject::Identifier,
+        field::unowned::subject::VitalStatus,
+        field::unowned::subject::AgeAtVitalStatus,
 
         // Harmonized sample fields.
+        field::unowned::sample::AgeAtDiagnosis,
         field::unowned::sample::DiseasePhase,
         field::unowned::sample::TissueType,
         field::unowned::sample::TumorClassification,
+        field::unowned::sample::TumorTissueMorphology,
+        field::unowned::sample::AgeAtCollection,
 
         // Unharmonized fields.
         field::owned::Field,
@@ -241,6 +251,7 @@ that some fields have been left out of the definitions for brevity.
         models::metadata::field::Description,
         models::metadata::field::description::Harmonized,
         models::metadata::field::description::Unharmonized,
+        models::metadata::field::description::harmonized::Standard,
 
         // Namespace models.
         models::Namespace,
@@ -249,7 +260,6 @@ that some fields have been left out of the definitions for brevity.
 
         // Url model.
         models::Url,
-
 
         // General responses.
         responses::Errors,

--- a/packages/ccdi-server/src/filter.rs
+++ b/packages/ccdi-server/src/filter.rs
@@ -103,6 +103,8 @@ where
 ///         race: None,
 ///         ethnicity: None,
 ///         identifiers: None,
+///         vital_status: None,
+///         age_at_vital_status: None,
 ///     },
 /// );
 ///
@@ -118,6 +120,8 @@ where
 ///         race: Some(String::from("Asian")),
 ///         ethnicity: None,
 ///         identifiers: None,
+///         vital_status: None,
+///         age_at_vital_status: None,
 ///     },
 /// );
 ///
@@ -132,6 +136,8 @@ where
 ///         race: None,
 ///         ethnicity: None,
 ///         identifiers: None,
+///         vital_status: None,
+///         age_at_vital_status: None,
 ///     },
 /// );
 ///

--- a/packages/ccdi-server/src/filter/sample.rs
+++ b/packages/ccdi-server/src/filter/sample.rs
@@ -13,6 +13,9 @@ impl FilterMetadataField<Sample, FilterSampleParams> for Vec<Sample> {
             "disease_phase" => params.disease_phase.as_ref(),
             "tissue_type" => params.tissue_type.as_ref(),
             "tumor_classification" => params.tumor_classification.as_ref(),
+            "age_at_diagnosis" => params.age_at_diagnosis.as_ref(),
+            "age_at_collection" => params.age_at_collection.as_ref(),
+            "tumor_tissue_morphology" => params.tumor_tissue_morphology.as_ref(),
             _ => unreachable!("unhandled sample metadata field: {field}"),
         };
 
@@ -38,6 +41,18 @@ impl FilterMetadataField<Sample, FilterSampleParams> for Vec<Sample> {
                         .metadata()
                         .and_then(|metadata| metadata.tumor_classification())
                         .map(|tumor_classification| vec![tumor_classification.to_string()]),
+                    "age_at_diagnosis" => sample
+                        .metadata()
+                        .and_then(|metadata| metadata.age_at_diagnosis())
+                        .map(|age_at_diagnosis| vec![age_at_diagnosis.to_string()]),
+                    "age_at_collection" => sample
+                        .metadata()
+                        .and_then(|metadata| metadata.age_at_collection())
+                        .map(|age_at_collection| vec![age_at_collection.to_string()]),
+                    "tumor_tissue_morphology" => sample
+                        .metadata()
+                        .and_then(|metadata| metadata.tumor_tissue_morphology())
+                        .map(|tumor_tissue_morphology| vec![tumor_tissue_morphology.to_string()]),
                     _ => unreachable!("unhandled sample metadata field: {field}"),
                 };
 

--- a/packages/ccdi-server/src/filter/subject.rs
+++ b/packages/ccdi-server/src/filter/subject.rs
@@ -14,6 +14,8 @@ impl FilterMetadataField<Subject, FilterSubjectParams> for Vec<Subject> {
             "race" => params.race.as_ref(),
             "ethnicity" => params.ethnicity.as_ref(),
             "identifiers" => params.identifiers.as_ref(),
+            "vital_status" => params.vital_status.as_ref(),
+            "age_at_vital_status" => params.age_at_vital_status.as_ref(),
             _ => unreachable!("unhandled subject metadata field: {field}"),
         };
 
@@ -54,6 +56,14 @@ impl FilterMetadataField<Subject, FilterSubjectParams> for Vec<Subject> {
                                 .map(|r| r.to_string())
                                 .collect::<Vec<String>>()
                         }),
+                    "vital_status" => subject
+                        .metadata()
+                        .and_then(|metadata| metadata.vital_status())
+                        .map(|vital_status| vec![vital_status.to_string()]),
+                    "age_at_vital_status" => subject
+                        .metadata()
+                        .and_then(|metadata| metadata.age_at_vital_status())
+                        .map(|age_at_vital_status| vec![age_at_vital_status.to_string()]),
                     _ => unreachable!("unhandled subject metadata field: {field}"),
                 };
 

--- a/packages/ccdi-server/src/params/filter.rs
+++ b/packages/ccdi-server/src/params/filter.rs
@@ -30,7 +30,7 @@ pub struct Subject {
     #[param(required = false, nullable = false)]
     pub race: Option<String>,
 
-    /// matches any subject where the `ethnicity` field matches the string provided.
+    /// Matches any subject where the `ethnicity` field matches the string provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[param(required = false, nullable = false)]
     pub ethnicity: Option<String>,
@@ -43,6 +43,16 @@ pub struct Subject {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[param(required = false, nullable = false)]
     pub identifiers: Option<String>,
+
+    /// Matches any subject where the `vital_status` field matches the string provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub vital_status: Option<String>,
+
+    /// Matches any subject where the `age_at_vital_status` field matches the string provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub age_at_vital_status: Option<String>,
 }
 
 /// Parameters for filtering subjects.
@@ -56,21 +66,36 @@ pub struct Subject {
 #[derive(Debug, Default, Deserialize, IntoParams, Introspect, Serialize)]
 #[into_params(parameter_in = Query)]
 pub struct Sample {
-    /// Matches any subject where the `disease_phase` field matches the string
+    /// Matches any sample where the `disease_phase` field matches the string
     /// provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[param(required = false, nullable = false)]
     pub disease_phase: Option<String>,
 
-    /// Matches any subject where the `tissue_type` field matches the string
+    /// Matches any sample where the `tissue_type` field matches the string
     /// provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[param(required = false, nullable = false)]
     pub tissue_type: Option<String>,
 
-    /// Matches any subject where the `tumor_classification` field matches the
+    /// Matches any sample where the `tumor_classification` field matches the
     /// string provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[param(required = false, nullable = false)]
     pub tumor_classification: Option<String>,
+
+    /// Matches any sample where the `age_at_diagnosis` field matches the string provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub age_at_diagnosis: Option<String>,
+
+    /// Matches any sample where the `age_at_collection` field matches the string provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub age_at_collection: Option<String>,
+
+    /// Matches any sample where the `tumor_tissue_morphology` field matches the string provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub tumor_tissue_morphology: Option<String>,
 }

--- a/packages/ccdi-server/src/routes/sample.rs
+++ b/packages/ccdi-server/src/routes/sample.rs
@@ -359,6 +359,20 @@ pub async fn samples_by_count(path: Path<String>, samples: Data<Store>) -> impl 
 
 fn parse_field(field: &str, sample: &Sample) -> Option<Value> {
     match field {
+        "age_at_diagnosis" => match sample.metadata() {
+            Some(metadata) => metadata
+                .age_at_diagnosis()
+                .as_ref()
+                .map(|age_at_diagnosis| Value::String(age_at_diagnosis.value().to_string())),
+            None => None,
+        },
+        "age_at_collection" => match sample.metadata() {
+            Some(metadata) => metadata
+                .age_at_collection()
+                .as_ref()
+                .map(|age_at_collection| Value::String(age_at_collection.value().to_string())),
+            None => None,
+        },
         "disease_phase" => match sample.metadata() {
             Some(metadata) => metadata
                 .disease_phase()
@@ -376,6 +390,13 @@ fn parse_field(field: &str, sample: &Sample) -> Option<Value> {
         "tumor_classification" => match sample.metadata() {
             Some(metadata) => metadata
                 .tumor_classification()
+                .as_ref()
+                .map(|value| Value::String(value.value().to_string())),
+            None => None,
+        },
+        "tumor_tissue_morphology" => match sample.metadata() {
+            Some(metadata) => metadata
+                .tumor_tissue_morphology()
                 .as_ref()
                 .map(|value| Value::String(value.value().to_string())),
             None => None,

--- a/packages/ccdi-server/src/routes/subject.rs
+++ b/packages/ccdi-server/src/routes/subject.rs
@@ -391,6 +391,20 @@ fn parse_field(field: &str, subject: &Subject) -> Option<Value> {
             }),
             None => None,
         },
+        "vital_status" => match subject.metadata() {
+            Some(metadata) => metadata
+                .vital_status()
+                .as_ref()
+                .map(|vital_status| Value::String(vital_status.value().to_string())),
+            None => None,
+        },
+        "age_at_vital_status" => match subject.metadata() {
+            Some(metadata) => metadata
+                .age_at_vital_status()
+                .as_ref()
+                .map(|age_at_vital_status| Value::String(age_at_vital_status.value().to_string())),
+            None => None,
+        },
         _ => None,
     }
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -711,6 +711,18 @@ components:
       - Primary
       - Regional
       - Unknown
+    cde.v1.sample.TumorTissueMorphology:
+      type: string
+      description: |-
+        **`caDSR CDE 11326261 v1.00`**
+
+        This metadata element is defined by the caDSR as "The microscopic anatomy of
+        normal and abnormal cells and tissues of the specimen as captured in the
+        morphology codes of the International Classification of Diseases for
+        Oncology, 3rd Edition (ICD-O-3)."
+
+        Link:
+        <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11326261%20and%20ver_nr=1>
     cde.v1.subject.Identifier:
       type: object
       description: |-
@@ -775,6 +787,22 @@ components:
       - F
       - M
       - UNDIFFERENTIATED
+    cde.v1.subject.VitalStatus:
+      type: string
+      description: |-
+        **`caDSR CDE 2847330 v1.00`**
+
+        This metadata element is defined by the caDSR as "The response to a question
+        that describes a participant's survival status."
+
+        Link:
+        <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=2847330%20and%20ver_nr=1>
+      enum:
+      - Not reported
+      - Alive
+      - Dead
+      - Unknown
+      - Unspecified
     cde.v2.sample.TissueType:
       type: string
       description: |-
@@ -883,6 +911,44 @@ components:
         comment:
           type: string
           description: A free-text comment field.
+    field.unowned.sample.AgeAtCollection:
+      type: object
+      required:
+      - value
+      properties:
+        value:
+          $ref: '#/components/schemas/models.sample.metadata.AgeAtCollection'
+        ancestors:
+          type: array
+          items:
+            type: string
+          description: |-
+            The ancestors from which this field was derived.
+
+            Ancestors should be provided as period (`.`) delimited paths
+            from the `metadata` key in the subject response object.
+        comment:
+          type: string
+          description: A free-text comment field.
+    field.unowned.sample.AgeAtDiagnosis:
+      type: object
+      required:
+      - value
+      properties:
+        value:
+          $ref: '#/components/schemas/models.sample.metadata.AgeAtDiagnosis'
+        ancestors:
+          type: array
+          items:
+            type: string
+          description: |-
+            The ancestors from which this field was derived.
+
+            Ancestors should be provided as period (`.`) delimited paths
+            from the `metadata` key in the subject response object.
+        comment:
+          type: string
+          description: A free-text comment field.
     field.unowned.sample.DiseasePhase:
       type: object
       required:
@@ -940,6 +1006,44 @@ components:
         comment:
           type: string
           description: A free-text comment field.
+    field.unowned.sample.TumorTissueMorphology:
+      type: object
+      required:
+      - value
+      properties:
+        value:
+          $ref: '#/components/schemas/cde.v1.sample.TumorTissueMorphology'
+        ancestors:
+          type: array
+          items:
+            type: string
+          description: |-
+            The ancestors from which this field was derived.
+
+            Ancestors should be provided as period (`.`) delimited paths
+            from the `metadata` key in the subject response object.
+        comment:
+          type: string
+          description: A free-text comment field.
+    field.unowned.subject.AgeAtVitalStatus:
+      type: object
+      required:
+      - value
+      properties:
+        value:
+          $ref: '#/components/schemas/models.subject.metadata.AgeAtVitalStatus'
+        ancestors:
+          type: array
+          items:
+            type: string
+          description: |-
+            The ancestors from which this field was derived.
+
+            Ancestors should be provided as period (`.`) delimited paths
+            from the `metadata` key in the subject response object.
+        comment:
+          type: string
+          description: A free-text comment field.
     field.unowned.subject.Ethnicity:
       type: object
       required:
@@ -985,6 +1089,25 @@ components:
       properties:
         value:
           $ref: '#/components/schemas/cde.v1.subject.Sex'
+        ancestors:
+          type: array
+          items:
+            type: string
+          description: |-
+            The ancestors from which this field was derived.
+
+            Ancestors should be provided as period (`.`) delimited paths
+            from the `metadata` key in the subject response object.
+        comment:
+          type: string
+          description: A free-text comment field.
+    field.unowned.subject.VitalStatus:
+      type: object
+      required:
+      - value
+      properties:
+        value:
+          $ref: '#/components/schemas/cde.v1.subject.VitalStatus'
         ancestors:
           type: array
           items:
@@ -1580,8 +1703,7 @@ components:
       required:
       - harmonized
       - path
-      - standard
-      - url
+      - wiki_url
       properties:
         harmonized:
           type: boolean
@@ -1595,13 +1717,12 @@ components:
           description: |-
             A comma (`.`) delimited path to the field's location on the `metadata`
             objects returned by the various subject endpoints.
-        standard:
-          type: string
-          description: |-
-            The proper name of the standard to which this field is harmonized (defined
-            by the documentation for the CCDI metadata fields).
-        url:
+        wiki_url:
           $ref: '#/components/schemas/models.Url'
+        standard:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.description.harmonized.Standard'
+          nullable: true
     models.metadata.field.description.Unharmonized:
       type: object
       description: |-
@@ -1649,6 +1770,18 @@ components:
           allOf:
           - $ref: '#/components/schemas/models.Url'
           nullable: true
+    models.metadata.field.description.harmonized.Standard:
+      type: object
+      description: A standard to which a field is harmonized.
+      required:
+      - name
+      - url
+      properties:
+        name:
+          type: string
+          description: The name.
+        url:
+          $ref: '#/components/schemas/models.Url'
     models.namespace.Description:
       type: string
       description: |-
@@ -1688,10 +1821,17 @@ components:
       type: object
       description: Metadata associated with a sample.
       required:
+      - age_at_diagnosis
       - disease_phase
       - tissue_type
       - tumor_classification
+      - tumor_tissue_morphology
+      - age_at_collection
       properties:
+        age_at_diagnosis:
+          allOf:
+          - $ref: '#/components/schemas/field.unowned.sample.AgeAtDiagnosis'
+          nullable: true
         disease_phase:
           allOf:
           - $ref: '#/components/schemas/field.unowned.sample.DiseasePhase'
@@ -1704,8 +1844,38 @@ components:
           allOf:
           - $ref: '#/components/schemas/field.unowned.sample.TumorClassification'
           nullable: true
+        tumor_tissue_morphology:
+          allOf:
+          - $ref: '#/components/schemas/field.unowned.sample.TumorTissueMorphology'
+          nullable: true
+        age_at_collection:
+          allOf:
+          - $ref: '#/components/schemas/field.unowned.sample.AgeAtCollection'
+          nullable: true
         unharmonized:
           $ref: '#/components/schemas/fields.Unharmonized'
+    models.sample.metadata.AgeAtCollection:
+      type: number
+      format: float
+      description: |-
+        The approximate age of collection in days.
+
+        * When the age at collection is collected by the source server in days, the
+        number of days is reported directly.
+        * When the age at collection is collected by the source server in years, the
+        number of years is multiplied by 365.25 to arrive at an approximate number
+        of days.
+    models.sample.metadata.AgeAtDiagnosis:
+      type: number
+      format: float
+      description: |-
+        The approximate age of diagnosis in days.
+
+        * When the age at diagnosis is collected by the source server in days, the
+        number of days is reported directly.
+        * When the age at diagnosis is collected by the source server in years, the
+        number of years is multiplied by 365.25 to arrive at an approximate number
+        of days.
     models.subject.Identifier:
       $ref: '#/components/schemas/cde.v1.subject.Identifier'
     models.subject.Kind:
@@ -1724,6 +1894,8 @@ components:
       - race
       - ethnicity
       - identifiers
+      - vital_status
+      - age_at_vital_status
       properties:
         sex:
           allOf:
@@ -1749,8 +1921,27 @@ components:
             Note that this list of identifiers *must* include the main identifier
             for the [`Subject`].
           nullable: true
+        vital_status:
+          allOf:
+          - $ref: '#/components/schemas/field.unowned.subject.VitalStatus'
+          nullable: true
+        age_at_vital_status:
+          allOf:
+          - $ref: '#/components/schemas/field.unowned.subject.AgeAtVitalStatus'
+          nullable: true
         unharmonized:
           $ref: '#/components/schemas/fields.Unharmonized'
+    models.subject.metadata.AgeAtVitalStatus:
+      type: number
+      format: float
+      description: |-
+        The approximate age at vital status in days.
+
+        * When the age at vital status is collected by the source server in days,
+        the number of days is reported directly.
+        * When the age at vital status is collected by the source server in years,
+        the number of years is multiplied by 365.25 to arrive at an approximate
+        number of days.
     responses.Errors:
       type: object
       description: A wrapper around one or more [errors](Kind).


### PR DESCRIPTION
**PR Close Date:** January 12, 2023

Adds five new metadata elements as ratified by the metadata harmonization group.

* Adds vital status to subject (CDE 2847330 v1.00, #42)
* Adds age at vital status to subject (no associated CDE, #45)
* Adds age at diagnosis to sample (no associated CDE, #37)
* Adds age at collection to sample (no associated CDE, #44)
* Adds tumor tissue morphology to sample (CDE 11326261 v1.00, #43)

Other notable changes:

* The definition of harmonized metadata description has now been broadened to account for harmonized metadata elements that have no backing CDE:
  * The top level URL field has been renamed to `wiki_url` and the purpose has changed. Moving forward, this field points to a link within the federation's [wiki page](https://github.com/CBIIT/ccdi-federation-api/wiki) that describes the metadata element, which is guaranteed to exist for every harmonized metadata element.
  * The standard to which a harmonized metadata field is aligned (up until this point, always a CDE) is contained within the optional `standard` key. The `standard` key can contain the name of the standard to which the field is harmonized and a URL to learn more about that standard.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
