### PR TITLE
fix: fixes issues with v0.6.0

### DIFF
--- a/packages/ccdi-cde/src/v1/sample/tumor_tissue_morphology.rs
+++ b/packages/ccdi-cde/src/v1/sample/tumor_tissue_morphology.rs
@@ -16,14 +16,14 @@ use crate::CDE;
 /// <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11326261%20and%20ver_nr=1>
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema, Introspect)]
 #[schema(as = cde::v1::sample::TumorTissueMorphology)]
-pub struct TumorTissueMorphology(
+pub struct TumorTissueMorphology {
     /// The ICD-O-3 code.
-    String,
-);
+    icd_o_3: String,
+}
 
 impl From<String> for TumorTissueMorphology {
     fn from(value: String) -> Self {
-        TumorTissueMorphology(value)
+        TumorTissueMorphology { icd_o_3: value }
     }
 }
 
@@ -31,6 +31,6 @@ impl CDE for TumorTissueMorphology {}
 
 impl std::fmt::Display for TumorTissueMorphology {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.icd_o_3)
     }
 }

--- a/packages/ccdi-models/src/metadata/field/description/harmonized/sample.rs
+++ b/packages/ccdi-models/src/metadata/field/description/harmonized/sample.rs
@@ -105,7 +105,7 @@ impl description::r#trait::Description for cde::v1::sample::TumorTissueMorpholog
         let members = Self::members().unwrap();
 
         description::Description::Harmonized(Harmonized::new(
-            Kind::Enum,
+            Kind::Struct,
             String::from("tumor_tissue_morphology"),
             entity.description().to_string(),
             Url::try_from("https://github.com/CBIIT/ccdi-federation-api/wiki/Sample-Metadata-Fields#tumor_tissue_morphology").unwrap(),

--- a/packages/ccdi-models/src/metadata/field/description/harmonized/subject.rs
+++ b/packages/ccdi-models/src/metadata/field/description/harmonized/subject.rs
@@ -22,6 +22,7 @@ pub fn get_field_descriptions() -> Vec<description::Description> {
         cde::v2::subject::Ethnicity::description(),
         cde::v1::subject::Identifier::description(),
         cde::v1::subject::VitalStatus::description(),
+        crate::subject::metadata::AgeAtVitalStatus::description(),
     ]
 }
 

--- a/packages/ccdi-spec/src/utils/markdown.rs
+++ b/packages/ccdi-spec/src/utils/markdown.rs
@@ -111,7 +111,7 @@ fn write_variant_members(
             // member in the `members` list is a [`Member::Variant`]. If the
             // first element is a [`Member::Variant`], then all of them should
             // be.
-            _ => unreachable!(),
+            v => unreachable!("{:?}", v),
         };
 
         // Write the row.


### PR DESCRIPTION
* Corrects the description of the sample metadata `tumor_tissue_morphology` to be specified as a struct. Additionally, add the `icd_o_3` code as a named struct field so that it will be named in the wiki.
* Adds the `age_at_vital_status` subject metadata to `get_field_descriptions()` so that it will be included in the wiki page generation.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
