### PR TITLE
revise: adds summaries to `/subject` and `/sample` pages

### DIFF
--- a/packages/ccdi-cde/src/lib.rs
+++ b/packages/ccdi-cde/src/lib.rs
@@ -7,7 +7,6 @@
 #![warn(rust_2021_compatibility)]
 #![warn(missing_debug_implementations)]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![feature(trivial_bounds)]
 
 use introspect::Entity;
 use introspect::Introspected;

--- a/packages/ccdi-cde/src/parse/cde/entity.rs
+++ b/packages/ccdi-cde/src/parse/cde/entity.rs
@@ -227,8 +227,6 @@ fn parse_url_line(lines: &mut Peekable<Lines<'_>>) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use regex::Regex;
-
     use super::*;
 
     #[test]

--- a/packages/ccdi-models/src/file.rs
+++ b/packages/ccdi-models/src/file.rs
@@ -425,12 +425,9 @@ impl Ord for File {
 mod tests {
     use std::cmp::Ordering;
 
-    use crate::gateway::AnonymousOrReference;
-    use crate::gateway::Link;
     use crate::sample;
     use crate::Gateway;
     use crate::Namespace;
-    use crate::Url;
 
     use super::*;
 

--- a/packages/ccdi-openapi/src/api.rs
+++ b/packages/ccdi-openapi/src/api.rs
@@ -291,6 +291,10 @@ that some fields have been left out of the definitions for brevity.
         responses::summary::Counts,
         responses::Summary,
 
+        // Cross-entity responses.
+        responses::entity::Summary,
+        responses::entity::Counts,
+
         // Subject responses.
         responses::Subject,
         responses::Subjects,

--- a/packages/ccdi-server/src/responses.rs
+++ b/packages/ccdi-server/src/responses.rs
@@ -1,6 +1,7 @@
 //! Responses for the server.
 
 pub mod by;
+pub mod entity;
 pub mod error;
 pub mod file;
 pub mod info;

--- a/packages/ccdi-server/src/responses/entity.rs
+++ b/packages/ccdi-server/src/responses/entity.rs
@@ -1,0 +1,35 @@
+//! Cross-entity elements.
+
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+mod counts;
+pub use counts::Counts;
+
+/// A summary of a paged entity response.
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
+#[schema(as = responses::entity::Summary)]
+pub struct Summary {
+    #[schema(value_type = responses::entity::Counts)]
+    counts: Counts,
+}
+
+impl Summary {
+    /// Creates a new [`Summary`] response.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_server as server;
+    ///
+    /// use server::responses::entity::Counts;
+    /// use server::responses::entity::Summary;
+    ///
+    /// let counts = Counts::new(1, 10);
+    /// let summary = Summary::new(counts);
+    /// ```
+    pub fn new(counts: Counts) -> Self {
+        Self { counts }
+    }
+}

--- a/packages/ccdi-server/src/responses/entity/counts.rs
+++ b/packages/ccdi-server/src/responses/entity/counts.rs
@@ -1,0 +1,33 @@
+//! Paged counts included within every entity endpoint.
+
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// Counts that summarize the contents of a paged entity response.
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
+#[schema(as = responses::entity::Counts)]
+pub struct Counts {
+    /// The number of entities within the currently selected page in the result set.
+    current: usize,
+
+    /// The number of entities across all pages in the result set.
+    all: usize,
+}
+
+impl Counts {
+    /// Creates a new [`Counts`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_server as server;
+    ///
+    /// use server::responses::entity::Counts;
+    ///
+    /// let summary = Counts::new(1, 10);
+    /// ```
+    pub fn new(current: usize, all: usize) -> Self {
+        Self { current, all }
+    }
+}

--- a/packages/ccdi-server/src/responses/file.rs
+++ b/packages/ccdi-server/src/responses/file.rs
@@ -106,7 +106,8 @@ impl Files {
     ///     },
     /// );
     ///
-    /// let response = server::responses::Files::try_new(vec![file], vec![gateway]).unwrap();
+    /// let files = server::responses::file::data::Files::from((vec![file], 10usize));
+    /// let response = server::responses::Files::try_new(files, vec![gateway]).unwrap();
     /// ```
     pub fn try_new(
         files: impl Into<data::Files>,
@@ -159,8 +160,6 @@ mod tests {
     use ccdi_models::Url;
     use nonempty::NonEmpty;
 
-    use crate::responses::Files;
-
     #[test]
     fn missing_gateways() {
         let namespace = Namespace::try_new(
@@ -189,7 +188,8 @@ mod tests {
             },
         );
 
-        let err = Files::try_new(vec![file], vec![gateway]).unwrap_err();
+        let err =
+            Files::try_new(data::Files::from((vec![file], 10usize)), vec![gateway]).unwrap_err();
         assert!(matches!(err, Error::MissingGateways(_)));
         assert_eq!(err.to_string(), String::from("missing gateways: name"));
     }
@@ -232,7 +232,7 @@ mod tests {
             ),
         ];
 
-        let err = Files::try_new(vec![file], gateways).unwrap_err();
+        let err = Files::try_new(data::Files::from((vec![file], 10usize)), gateways).unwrap_err();
         assert!(matches!(err, Error::ExtraneousGateways(_)));
         assert_eq!(
             err.to_string(),

--- a/packages/ccdi-server/src/responses/sample.rs
+++ b/packages/ccdi-server/src/responses/sample.rs
@@ -4,6 +4,9 @@ use utoipa::ToSchema;
 
 use ccdi_models as models;
 
+use crate::responses::entity::Counts;
+use crate::responses::entity::Summary;
+
 /// A response representing a single [`Sample`](models::Sample).
 #[derive(Debug, Deserialize, Serialize, ToSchema)]
 #[schema(as = responses::Sample)]
@@ -28,13 +31,22 @@ pub struct Sample {
 #[derive(Debug, Deserialize, Serialize, ToSchema)]
 #[schema(as = responses::Samples)]
 pub struct Samples {
+    /// A summary of this paged result set.
+    #[schema(value_type = responses::entity::Summary)]
+    summary: Summary,
+
     /// The samples.
     #[schema(nullable = false)]
     data: Vec<models::Sample>,
 }
 
-impl From<Vec<models::Sample>> for Samples {
-    fn from(samples: Vec<models::Sample>) -> Self {
-        Self { data: samples }
+impl From<(Vec<models::Sample>, usize)> for Samples {
+    fn from((samples, count): (Vec<models::Sample>, usize)) -> Self {
+        let counts = Counts::new(samples.len(), count);
+
+        Self {
+            summary: Summary::new(counts),
+            data: samples,
+        }
     }
 }

--- a/packages/ccdi-server/src/responses/subject.rs
+++ b/packages/ccdi-server/src/responses/subject.rs
@@ -4,6 +4,9 @@ use utoipa::ToSchema;
 
 use ccdi_models as models;
 
+use crate::responses::entity::Counts;
+use crate::responses::entity::Summary;
+
 /// A response representing a single [`Subject`](models::Subject).
 #[derive(Debug, Deserialize, Serialize, ToSchema)]
 #[schema(as = responses::Subject)]
@@ -28,13 +31,22 @@ pub struct Subject {
 #[derive(Debug, Deserialize, Serialize, ToSchema)]
 #[schema(as = responses::Subjects)]
 pub struct Subjects {
+    /// A summary of this paged result set.
+    #[schema(value_type = responses::entity::Summary)]
+    summary: Summary,
+
     /// The subjects.
     #[schema(nullable = false)]
     data: Vec<models::Subject>,
 }
 
-impl From<Vec<models::Subject>> for Subjects {
-    fn from(subjects: Vec<models::Subject>) -> Self {
-        Self { data: subjects }
+impl From<(Vec<models::Subject>, usize)> for Subjects {
+    fn from((subjects, count): (Vec<models::Subject>, usize)) -> Self {
+        let counts = Counts::new(subjects.len(), count);
+
+        Self {
+            summary: Summary::new(counts),
+            data: subjects,
+        }
     }
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -2287,8 +2287,11 @@ components:
 
         Of course, if there is a provided sort order, use that instead.
       required:
+      - summary
       - data
       properties:
+        summary:
+          $ref: '#/components/schemas/responses.entity.Summary'
         data:
           type: array
           items:
@@ -2315,8 +2318,11 @@ components:
 
         Of course, if there is a provided sort order, use that instead.
       required:
+      - summary
       - data
       properties:
+        summary:
+          $ref: '#/components/schemas/responses.entity.Summary'
         data:
           type: array
           items:
@@ -2364,6 +2370,29 @@ components:
           additionalProperties:
             type: integer
             minimum: 0
+    responses.entity.Counts:
+      type: object
+      description: Counts that summarize the contents of a paged entity response.
+      required:
+      - current
+      - all
+      properties:
+        current:
+          type: integer
+          description: The number of entities within the currently selected page in the result set.
+          minimum: 0
+        all:
+          type: integer
+          description: The number of entities across all pages in the result set.
+          minimum: 0
+    responses.entity.Summary:
+      type: object
+      description: A summary of a paged entity response.
+      required:
+      - counts
+      properties:
+        counts:
+          $ref: '#/components/schemas/responses.entity.Counts'
     responses.error.Kind:
       allOf:
       - oneOf:
@@ -2504,8 +2533,11 @@ components:
       type: object
       description: Files within a [`Data`](super::Data) response.
       required:
+      - summary
       - files
       properties:
+        summary:
+          $ref: '#/components/schemas/responses.entity.Summary'
         files:
           type: array
           items:


### PR DESCRIPTION
**PR Close Date:** February 9, 2024

This pull request adds a `summary` object to the top-level response for `/sample`, `/subject`, and `/file`. This was discussed in, if memory serves correct, the last meeting in December.

Notably, `/subject/summary` and `/sample/summary` already have the total count included.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
