### PR TITLE
revise: enables required pagination for entity root endpoints

### DIFF
--- a/packages/ccdi-server/src/params/pagination.rs
+++ b/packages/ccdi-server/src/params/pagination.rs
@@ -31,19 +31,17 @@ pub struct Pagination {
     /// The page to retrieve.
     ///
     /// This is a 1-based index of a page within a page set. The value of `page`
-    /// **must** default to `1` when pagination is enabled but this parameter is
-    /// not provided. Pagination is enabled if this parameter is provided to the
-    /// endpoint.
+    /// **must** default to `1` when this parameter is not provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[param(required = false, nullable = false)]
     page: Option<usize>,
 
     /// The number of results per page.
     ///
-    /// Each server can select its own default value for `per_page` if
-    /// pagination is enabled but this parameter is not provided. A default
-    /// value of `100` is recommended if all values are equally reasonable.
-    /// Pagination is enabled if this parameter is provided to the endpoint.
+    /// Each server can select its own default value for `per_page` when this
+    /// parameter is not provided. That said, the convention within the
+    /// community is to use `100` as a default value if any value is equally
+    /// reasonable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[param(required = false, nullable = false)]
     per_page: Option<usize>,

--- a/packages/ccdi-server/src/routes/sample.rs
+++ b/packages/ccdi-server/src/routes/sample.rs
@@ -91,8 +91,9 @@ pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
 ///
 /// ### Pagination
 ///
-/// This endpoint supports pagination. Pagination is enabled by providing one of
-/// the pagination-related query parameters below.
+/// This endpoint is paginated. Users may override the default pagination
+/// parameters by providing one or more of the pagination-related query
+/// parameters below.
 ///
 /// ### Filtering
 ///
@@ -178,16 +179,11 @@ pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
                     - `prev` (_Optional_). A link to the previous page (if it \
                     exists).\n\n\
                     ### Requirements\n\n\
-                    - This header is required to exist when pagination is \
-                    enabled.\n\
-                    - It is also required _not_ to exist \
-                    when pagination is not enabled.\n\
-                    - When the header is present, this header must provide \
-                    links for at least the `first` and `last` rels.\n \
-                    - When the header is present, the `prev` and `next` links \
-                    must exist only (a) when there are multiple pages in the \
-                    result page set and (b) when the current page is not the \
-                    first or last page, respectively.\n\
+                    - This header _must_ provide links for at least the `first` \
+                    and `last` rels.\n \
+                    - The `prev` and `next` links must exist only (a) when there \
+                    are multiple pages in the result page set and (b) when the \
+                    current page is not the first or last page, respectively.\n\
                     - This list of links is unordered.\n\n \
                     ### Notes\n\n\
                     - HTTP 1.1 and HTTP 2.0 dictate that response \
@@ -241,15 +237,11 @@ pub async fn sample_index(
 
     let samples = filter::<Sample, FilterSampleParams>(samples, filter_params.0);
 
-    if pagination_params.0.page().is_some() || pagination_params.0.per_page().is_some() {
-        paginate::response::<Sample, Samples>(
-            pagination_params.0,
-            samples,
-            "http://localhost:8000/sample",
-        )
-    } else {
-        HttpResponse::Ok().json(Samples::from(samples))
-    }
+    paginate::response::<Sample, Samples>(
+        pagination_params.0,
+        samples,
+        "http://localhost:8000/sample",
+    )
 }
 
 /// Gets the sample matching the provided name (if the sample exists).

--- a/packages/ccdi-server/src/routes/subject.rs
+++ b/packages/ccdi-server/src/routes/subject.rs
@@ -84,8 +84,9 @@ pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
 ///
 /// ### Pagination
 ///
-/// This endpoint supports pagination. Pagination is enabled by providing one of
-/// the pagination-related query parameters below.
+/// This endpoint is paginated. Users may override the default pagination
+/// parameters by providing one or more of the pagination-related query
+/// parameters below.
 ///
 /// ### Filtering
 ///
@@ -171,16 +172,11 @@ pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
                     - `prev` (_Optional_). A link to the previous page (if it \
                     exists).\n\n\
                     ### Requirements\n\n\
-                    - This header is required to exist when pagination is \
-                    enabled.\n\
-                    - It is also required _not_ to exist \
-                    when pagination is not enabled.\n\
-                    - When the header is present, this header must provide \
-                    links for at least the `first` and `last` rels.\n \
-                    - When the header is present, the `prev` and `next` links \
-                    must exist only (a) when there are multiple pages in the \
-                    result page set and (b) when the current page is not the \
-                    first or last page, respectively.\n\
+                    - This header _must_ provide links for at least the `first` \
+                    and `last` rels.\n \
+                    - The `prev` and `next` links must exist only (a) when there \
+                    are multiple pages in the result page set and (b) when the \
+                    current page is not the first or last page, respectively.\n\
                     - This list of links is unordered.\n\n \
                     ### Notes\n\n\
                     - HTTP 1.1 and HTTP 2.0 dictate that response \
@@ -234,15 +230,11 @@ pub async fn subject_index(
 
     let subjects = filter::<Subject, FilterSubjectParams>(subjects, filter_params.0);
 
-    if pagination_params.0.page().is_some() || pagination_params.0.per_page().is_some() {
-        paginate::response::<Subject, Subjects>(
-            pagination_params.0,
-            subjects,
-            "http://localhost:8000/subject",
-        )
-    } else {
-        HttpResponse::Ok().json(Subjects::from(subjects))
-    }
+    paginate::response::<Subject, Subjects>(
+        pagination_params.0,
+        subjects,
+        "http://localhost:8000/subject",
+    )
 }
 
 /// Gets the subject matching the provided id (if the subject exists).

--- a/swagger.yml
+++ b/swagger.yml
@@ -26,8 +26,9 @@ paths:
 
         ### Pagination
 
-        This endpoint supports pagination. Pagination is enabled by providing one of
-        the pagination-related query parameters below.
+        This endpoint is paginated. Users may override the default pagination
+        parameters by providing one or more of the pagination-related query
+        parameters below.
 
         ### Filtering
 
@@ -121,9 +122,7 @@ paths:
           The page to retrieve.
 
           This is a 1-based index of a page within a page set. The value of `page`
-          **must** default to `1` when pagination is enabled but this parameter is
-          not provided. Pagination is enabled if this parameter is provided to the
-          endpoint.
+          **must** default to `1` when this parameter is not provided.
         required: false
         schema:
           type: integer
@@ -133,10 +132,10 @@ paths:
         description: |-
           The number of results per page.
 
-          Each server can select its own default value for `per_page` if
-          pagination is enabled but this parameter is not provided. A default
-          value of `100` is recommended if all values are equally reasonable.
-          Pagination is enabled if this parameter is provided to the endpoint.
+          Each server can select its own default value for `per_page` when this
+          parameter is not provided. That said, the convention within the
+          community is to use `100` as a default value if any value is equally
+          reasonable.
         required: false
         schema:
           type: integer
@@ -148,7 +147,7 @@ paths:
             link:
               schema:
                 type: string
-              description: "Links to URLs that may be of interest when paging through paginated responses. This header contains two or more links of interest. The format of the field is as follows: \n\n`Link: <URL>; rel=\"REL\"` \n### Relationships\n\nIn the format above, `URL` represents a valid URL for the link of interest and `REL` is one of four values: \n- `first` (_Required_). A link to the first page in the results (can be the same as `last` if there is only one page).\n- `last` (_Required_). A link to the first page in the results (can be the same as `first` if there is only one page).\n- `next` (_Optional_). A link to the next page (if it exists).\n- `prev` (_Optional_). A link to the previous page (if it exists).\n\n### Requirements\n\n- This header is required to exist when pagination is enabled.\n- It is also required _not_ to exist when pagination is not enabled.\n- When the header is present, this header must provide links for at least the `first` and `last` rels.\n - When the header is present, the `prev` and `next` links must exist only (a) when there are multiple pages in the result page set and (b) when the current page is not the first or last page, respectively.\n- This list of links is unordered.\n\n ### Notes\n\n- HTTP 1.1 and HTTP 2.0 dictate that response headers are case insensitive. Though not required, we recommend an all lowercase name of `link` for this response header."
+              description: "Links to URLs that may be of interest when paging through paginated responses. This header contains two or more links of interest. The format of the field is as follows: \n\n`Link: <URL>; rel=\"REL\"` \n### Relationships\n\nIn the format above, `URL` represents a valid URL for the link of interest and `REL` is one of four values: \n- `first` (_Required_). A link to the first page in the results (can be the same as `last` if there is only one page).\n- `last` (_Required_). A link to the first page in the results (can be the same as `first` if there is only one page).\n- `next` (_Optional_). A link to the next page (if it exists).\n- `prev` (_Optional_). A link to the previous page (if it exists).\n\n### Requirements\n\n- This header _must_ provide links for at least the `first` and `last` rels.\n - The `prev` and `next` links must exist only (a) when there are multiple pages in the result page set and (b) when the current page is not the first or last page, respectively.\n- This list of links is unordered.\n\n ### Notes\n\n- HTTP 1.1 and HTTP 2.0 dictate that response headers are case insensitive. Though not required, we recommend an all lowercase name of `link` for this response header."
           content:
             application/json:
               schema:
@@ -278,8 +277,9 @@ paths:
 
         ### Pagination
 
-        This endpoint supports pagination. Pagination is enabled by providing one of
-        the pagination-related query parameters below.
+        This endpoint is paginated. Users may override the default pagination
+        parameters by providing one or more of the pagination-related query
+        parameters below.
 
         ### Filtering
 
@@ -369,9 +369,7 @@ paths:
           The page to retrieve.
 
           This is a 1-based index of a page within a page set. The value of `page`
-          **must** default to `1` when pagination is enabled but this parameter is
-          not provided. Pagination is enabled if this parameter is provided to the
-          endpoint.
+          **must** default to `1` when this parameter is not provided.
         required: false
         schema:
           type: integer
@@ -381,10 +379,10 @@ paths:
         description: |-
           The number of results per page.
 
-          Each server can select its own default value for `per_page` if
-          pagination is enabled but this parameter is not provided. A default
-          value of `100` is recommended if all values are equally reasonable.
-          Pagination is enabled if this parameter is provided to the endpoint.
+          Each server can select its own default value for `per_page` when this
+          parameter is not provided. That said, the convention within the
+          community is to use `100` as a default value if any value is equally
+          reasonable.
         required: false
         schema:
           type: integer
@@ -396,7 +394,7 @@ paths:
             link:
               schema:
                 type: string
-              description: "Links to URLs that may be of interest when paging through paginated responses. This header contains two or more links of interest. The format of the field is as follows: \n\n`Link: <URL>; rel=\"REL\"` \n### Relationships\n\nIn the format above, `URL` represents a valid URL for the link of interest and `REL` is one of four values: \n- `first` (_Required_). A link to the first page in the results (can be the same as `last` if there is only one page).\n- `last` (_Required_). A link to the first page in the results (can be the same as `first` if there is only one page).\n- `next` (_Optional_). A link to the next page (if it exists).\n- `prev` (_Optional_). A link to the previous page (if it exists).\n\n### Requirements\n\n- This header is required to exist when pagination is enabled.\n- It is also required _not_ to exist when pagination is not enabled.\n- When the header is present, this header must provide links for at least the `first` and `last` rels.\n - When the header is present, the `prev` and `next` links must exist only (a) when there are multiple pages in the result page set and (b) when the current page is not the first or last page, respectively.\n- This list of links is unordered.\n\n ### Notes\n\n- HTTP 1.1 and HTTP 2.0 dictate that response headers are case insensitive. Though not required, we recommend an all lowercase name of `link` for this response header."
+              description: "Links to URLs that may be of interest when paging through paginated responses. This header contains two or more links of interest. The format of the field is as follows: \n\n`Link: <URL>; rel=\"REL\"` \n### Relationships\n\nIn the format above, `URL` represents a valid URL for the link of interest and `REL` is one of four values: \n- `first` (_Required_). A link to the first page in the results (can be the same as `last` if there is only one page).\n- `last` (_Required_). A link to the first page in the results (can be the same as `first` if there is only one page).\n- `next` (_Optional_). A link to the next page (if it exists).\n- `prev` (_Optional_). A link to the previous page (if it exists).\n\n### Requirements\n\n- This header _must_ provide links for at least the `first` and `last` rels.\n - The `prev` and `next` links must exist only (a) when there are multiple pages in the result page set and (b) when the current page is not the first or last page, respectively.\n- This list of links is unordered.\n\n ### Notes\n\n- HTTP 1.1 and HTTP 2.0 dictate that response headers are case insensitive. Though not required, we recommend an all lowercase name of `link` for this response header."
           content:
             application/json:
               schema:
@@ -526,8 +524,9 @@ paths:
 
         ### Pagination
 
-        This endpoint supports pagination. Pagination is enabled by providing one of
-        the pagination-related query parameters below.
+        This endpoint is paginated. Users may override the default pagination
+        parameters by providing one or more of the pagination-related query
+        parameters below.
 
         ### Ordering
 
@@ -541,9 +540,7 @@ paths:
           The page to retrieve.
 
           This is a 1-based index of a page within a page set. The value of `page`
-          **must** default to `1` when pagination is enabled but this parameter is
-          not provided. Pagination is enabled if this parameter is provided to the
-          endpoint.
+          **must** default to `1` when this parameter is not provided.
         required: false
         schema:
           type: integer
@@ -553,10 +550,10 @@ paths:
         description: |-
           The number of results per page.
 
-          Each server can select its own default value for `per_page` if
-          pagination is enabled but this parameter is not provided. A default
-          value of `100` is recommended if all values are equally reasonable.
-          Pagination is enabled if this parameter is provided to the endpoint.
+          Each server can select its own default value for `per_page` when this
+          parameter is not provided. That said, the convention within the
+          community is to use `100` as a default value if any value is equally
+          reasonable.
         required: false
         schema:
           type: integer
@@ -568,7 +565,7 @@ paths:
             link:
               schema:
                 type: string
-              description: "Links to URLs that may be of interest when paging through paginated responses. This header contains two or more links of interest. The format of the field is as follows: \n\n`Link: <URL>; rel=\"REL\"` \n### Relationships\n\nIn the format above, `URL` represents a valid URL for the link of interest and `REL` is one of four values: \n- `first` (_Required_). A link to the first page in the results (can be the same as `last` if there is only one page).\n- `last` (_Required_). A link to the first page in the results (can be the same as `first` if there is only one page).\n- `next` (_Optional_). A link to the next page (if it exists).\n- `prev` (_Optional_). A link to the previous page (if it exists).\n\n### Requirements\n\n- This header is required to exist when pagination is enabled.\n- It is also required _not_ to exist when pagination is not enabled.\n- When the header is present, this header must provide links for at least the `first` and `last` rels.\n - When the header is present, the `prev` and `next` links must exist only (a) when there are multiple pages in the result page set and (b) when the current page is not the first or last page, respectively.\n- This list of links is unordered.\n\n ### Notes\n\n- HTTP 1.1 and HTTP 2.0 dictate that response headers are case insensitive. Though not required, we recommend an all lowercase name of `link` for this response header."
+              description: "Links to URLs that may be of interest when paging through paginated responses. This header contains two or more links of interest. The format of the field is as follows: \n\n`Link: <URL>; rel=\"REL\"` \n### Relationships\n\nIn the format above, `URL` represents a valid URL for the link of interest and `REL` is one of four values: \n- `first` (_Required_). A link to the first page in the results (can be the same as `last` if there is only one page).\n- `last` (_Required_). A link to the first page in the results (can be the same as `first` if there is only one page).\n- `next` (_Optional_). A link to the next page (if it exists).\n- `prev` (_Optional_). A link to the previous page (if it exists).\n\n### Requirements\n\n- This header _must_ provide links for at least the `first` and `last` rels.\n - The `prev` and `next` links must exist only (a) when there are multiple pages in the result page set and (b) when the current page is not the first or last page, respectively.\n- This list of links is unordered.\n\n ### Notes\n\n- HTTP 1.1 and HTTP 2.0 dictate that response headers are case insensitive. Though not required, we recommend an all lowercase name of `link` for this response header."
           content:
             application/json:
               schema:


### PR DESCRIPTION
**PR Close Date:** February 9, 2024

This PR enforces that pagination is included by default in every root
entity endpoints (`/sample`, `/subject`, `/file`).

## Outstanding Questions

* Do we want to move the pagination links from the HTTP response headers
  to the JSON body response?

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
