### PR TITLE
feat: improve missing values in group by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   objects for primary entities (subject, sample, and file) by assigning it a
   value of `null` rather than simply omitting the key
   ([#84](https://github.com/CBIIT/ccdi-federation-api/pull/84)).
+- Revises the way missing or `null` results are displayed in group by endpoints.
+  In particular, there is now a top-level `missing` key in those responses
+  rather than using sentinel values to indicate missing data
+  ([#83][https://github.com/CBIIT/ccdi-federation-api/pull/83]).
 
 ## [v0.7.0] — 03-25-2024
 
@@ -62,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to be supported for the `/{entity}/by/{field}/count` endpoint
   ([#75](https://github.com/CBIIT/ccdi-federation-api/pull/75)).
     - The only current valid value for the `partition` query parameter at the moment is
-      `namespace`, though this may be expanded in the future. 
+      `namespace`, though this may be expanded in the future.
 
 ## Changed
 

--- a/packages/ccdi-server/src/responses/by/count/file.rs
+++ b/packages/ccdi-server/src/responses/by/count/file.rs
@@ -15,11 +15,16 @@ pub struct Results {
     /// The total number of counts in this result set.
     pub total: usize,
 
+    /// The total number of entries that are missing values. In this context,
+    /// "missing" means either (a) the individual metadata key is missing or (b)
+    /// the entire metadata object is missing.
+    pub missing: usize,
+
     /// The counts per value observed for the result set.
     pub values: IndexMap<String, usize>,
 }
 
-impl From<IndexMap<String, usize>> for Results {
+impl Results {
     /// Creates a new [`Results`] from an [`IndexMap<String, usize>`].
     ///
     /// # Examples
@@ -37,11 +42,16 @@ impl From<IndexMap<String, usize>> for Results {
     /// map.insert("CRAM".into(), 10);
     /// map.insert("VCF".into(), 10);
     ///
-    /// let results = Results::from(map);
+    /// let results = Results::new(map, 10);
     /// ```
-    fn from(values: IndexMap<String, usize>) -> Self {
-        let total = values.values().sum::<usize>();
-        Self { total, values }
+    pub fn new(values: IndexMap<String, usize>, missing: usize) -> Self {
+        let total = values.values().sum::<usize>() + missing;
+
+        Self {
+            total,
+            missing,
+            values,
+        }
     }
 }
 
@@ -80,7 +90,7 @@ impl NamespacePartitionedResult {
     /// map.insert("CRAM".into(), 10);
     /// map.insert("VCF".into(), 10);
     ///
-    /// let results = Results::from(map);
+    /// let results = Results::new(map, 10);
     ///
     /// let organization = Organization::new(
     ///     "example-organization"
@@ -137,7 +147,7 @@ impl From<Vec<NamespacePartitionedResult>> for NamespacePartitionedResults {
     /// map.insert("Relapse".into(), 10);
     /// map.insert("Metastasis".into(), 10);
     ///
-    /// let results = Results::from(map);
+    /// let results = Results::new(map, 10);
     ///
     /// let organization = Organization::new(
     ///     "example-organization"

--- a/packages/ccdi-server/src/responses/by/count/sample.rs
+++ b/packages/ccdi-server/src/responses/by/count/sample.rs
@@ -15,11 +15,16 @@ pub struct Results {
     /// The total number of counts in this result set.
     pub total: usize,
 
+    /// The total number of entries that are missing values. In this context,
+    /// "missing" means either (a) the individual metadata key is missing or (b)
+    /// the entire metadata object is missing.
+    pub missing: usize,
+
     /// The counts per value observed for the result set.
     pub values: IndexMap<String, usize>,
 }
 
-impl From<IndexMap<String, usize>> for Results {
+impl Results {
     /// Creates a new [`Results`] from an [`IndexMap<String, usize>`].
     ///
     /// # Examples
@@ -37,11 +42,16 @@ impl From<IndexMap<String, usize>> for Results {
     /// map.insert("Relapse".into(), 10);
     /// map.insert("Metastasis".into(), 10);
     ///
-    /// let results = Results::from(map);
+    /// let results = Results::new(map, 10);
     /// ```
-    fn from(values: IndexMap<String, usize>) -> Self {
-        let total = values.values().sum::<usize>();
-        Self { total, values }
+    pub fn new(values: IndexMap<String, usize>, missing: usize) -> Self {
+        let total = values.values().sum::<usize>() + missing;
+
+        Self {
+            total,
+            missing,
+            values,
+        }
     }
 }
 
@@ -80,7 +90,7 @@ impl NamespacePartitionedResult {
     /// map.insert("Relapse".into(), 10);
     /// map.insert("Metastasis".into(), 10);
     ///
-    /// let results = Results::from(map);
+    /// let results = Results::new(map, 10);
     ///
     /// let organization = Organization::new(
     ///     "example-organization"
@@ -137,7 +147,7 @@ impl From<Vec<NamespacePartitionedResult>> for NamespacePartitionedResults {
     /// map.insert("Relapse".into(), 10);
     /// map.insert("Metastasis".into(), 10);
     ///
-    /// let results = Results::from(map);
+    /// let results = Results::new(map, 10);
     ///
     /// let organization = Organization::new(
     ///     "example-organization"

--- a/packages/ccdi-server/src/responses/by/count/subject.rs
+++ b/packages/ccdi-server/src/responses/by/count/subject.rs
@@ -14,11 +14,16 @@ pub struct Results {
     /// The total number of counts in this result set.
     pub total: usize,
 
+    /// The total number of entries that are missing values. In this context,
+    /// "missing" means either (a) the individual metadata key is missing or (b)
+    /// the entire metadata object is missing.
+    pub missing: usize,
+
     /// The counts per value observed for the result set.
     pub values: IndexMap<String, usize>,
 }
 
-impl From<IndexMap<String, usize>> for Results {
+impl Results {
     /// Creates a new [`Results`] from an [`IndexMap<String, usize>`].
     ///
     /// # Examples
@@ -37,11 +42,16 @@ impl From<IndexMap<String, usize>> for Results {
     /// map.insert("M".into(), 26);
     /// map.insert("UNDIFFERENTIATED".into(), 31);
     ///
-    /// let results = Results::from(map);
+    /// let results = Results::new(map, 10);
     /// ```
-    fn from(values: IndexMap<String, usize>) -> Self {
-        let total = values.values().sum::<usize>();
-        Self { total, values }
+    pub fn new(values: IndexMap<String, usize>, missing: usize) -> Self {
+        let total = values.values().sum::<usize>() + missing;
+
+        Self {
+            total,
+            missing,
+            values,
+        }
     }
 }
 
@@ -81,7 +91,7 @@ impl NamespacePartitionedResult {
     /// map.insert("M".into(), 26);
     /// map.insert("UNDIFFERENTIATED".into(), 31);
     ///
-    /// let results = Results::from(map);
+    /// let results = Results::new(map, 10);
     ///
     /// let organization = Organization::new(
     ///     "example-organization"
@@ -139,7 +149,7 @@ impl From<Vec<NamespacePartitionedResult>> for NamespacePartitionedResults {
     /// map.insert("M".into(), 26);
     /// map.insert("UNDIFFERENTIATED".into(), 31);
     ///
-    /// let results = Results::from(map);
+    /// let results = Results::new(map, 10);
     ///
     /// let organization = Organization::new(
     ///     "example-organization"

--- a/packages/ccdi-server/src/routes.rs
+++ b/packages/ccdi-server/src/routes.rs
@@ -7,6 +7,3 @@ pub mod namespace;
 pub mod organization;
 pub mod sample;
 pub mod subject;
-
-const MISSING_GROUP_BY_KEY: &str = "missing";
-const NULL_GROUP_BY_KEY: &str = "null";

--- a/swagger.yml
+++ b/swagger.yml
@@ -2950,11 +2950,19 @@ components:
         total count).
       required:
       - total
+      - missing
       - values
       properties:
         total:
           type: integer
           description: The total number of counts in this result set.
+          minimum: 0
+        missing:
+          type: integer
+          description: |-
+            The total number of entries that are missing values. In this context,
+            "missing" means either (a) the individual metadata key is missing or (b)
+            the entire metadata object is missing.
           minimum: 0
         values:
           type: object
@@ -2995,11 +3003,19 @@ components:
         total count).
       required:
       - total
+      - missing
       - values
       properties:
         total:
           type: integer
           description: The total number of counts in this result set.
+          minimum: 0
+        missing:
+          type: integer
+          description: |-
+            The total number of entries that are missing values. In this context,
+            "missing" means either (a) the individual metadata key is missing or (b)
+            the entire metadata object is missing.
           minimum: 0
         values:
           type: object
@@ -3039,11 +3055,19 @@ components:
         and then summing the counts.
       required:
       - total
+      - missing
       - values
       properties:
         total:
           type: integer
           description: The total number of counts in this result set.
+          minimum: 0
+        missing:
+          type: integer
+          description: |-
+            The total number of entries that are missing values. In this context,
+            "missing" means either (a) the individual metadata key is missing or (b)
+            the entire metadata object is missing.
           minimum: 0
         values:
           type: object


### PR DESCRIPTION
**PR Close Date:** April 12, 2024

This is a smaller PR that improves the way that `null`/missing values are handled in count by methods. The need for this became apparent through developing #81 and #82. In particular, no sentinel values are used to indicate missing values—instead, a top-level `missing` key is introduced to count the missing values.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added a line describing the change in the `CHANGELOG.md` under `[Unreleased]`.
