### PR TITLE
 revise: make `metadata` key explicitly `null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Revises the data model for files to more closely match subjects and samples by
   adding a `ccdi_server::responses::File` object
   ([#82](https://github.com/CBIIT/ccdi-federation-api/pull/82)).
+- Ensures that all primary entities must explicitly exclude missing metadata
+  objects for primary entities (subject, sample, and file) by assigning it a
+  value of `null` rather than simply omitting the key
+  ([#84](https://github.com/CBIIT/ccdi-federation-api/pull/84)).
 
 ## [v0.7.0] — 03-25-2024
 

--- a/packages/ccdi-models/src/file.rs
+++ b/packages/ccdi-models/src/file.rs
@@ -83,8 +83,10 @@ pub struct File {
     gateways: NonEmpty<gateway::AnonymousOrReference>,
 
     /// Metadata associated with this [`File`].
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<models::file::Metadata>)]
+    #[schema(
+        value_type = Option<models::file::Metadata>,
+        nullable = true
+    )]
     metadata: Option<Metadata>,
 }
 

--- a/packages/ccdi-models/src/sample.rs
+++ b/packages/ccdi-models/src/sample.rs
@@ -42,8 +42,10 @@ pub struct Sample {
     subject: crate::subject::Identifier,
 
     /// Metadata associated with this [`Sample`].
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<models::sample::Metadata>)]
+    #[schema(
+        value_type = Option<models::sample::Metadata>,
+        nullable = true
+    )]
     metadata: Option<Metadata>,
 }
 

--- a/packages/ccdi-models/src/subject.rs
+++ b/packages/ccdi-models/src/subject.rs
@@ -38,8 +38,10 @@ pub struct Subject {
     kind: Kind,
 
     /// Metadata associated with this [`Subject`].
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schema(value_type = Option<models::subject::Metadata>)]
+    #[schema(
+        value_type = Option<models::subject::Metadata>,
+        nullable = true
+    )]
     metadata: Option<Metadata>,
 }
 


### PR DESCRIPTION
**PR Close Date:** April 12, 2024

When metadata is not available, it should be explicitly `null`. This follows the principles set out in [#81](https://github.com/CBIIT/ccdi-federation-api/pull/81).

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added a line describing the change in the `CHANGELOG.md` under `[Unreleased]`.
