### PR TITLE
fix: adds query filtering to the `/file` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to overlap with this concept)
   ([#81](https://github.com/CBIIT/ccdi-federation-api/pull/81)).
 
+### Fixed
+
+- Adds filtering to the `/file` endpoint
+  ([#88](https://github.com/CBIIT/ccdi-federation-api/pull/88)).
+
 ## [v0.7.0] — 03-25-2024
 
 ### Added

--- a/packages/ccdi-models/src/file/metadata/checksums.rs
+++ b/packages/ccdi-models/src/file/metadata/checksums.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use ccdi_cde as cde;
 use rand::distributions::Distribution;
 use rand::distributions::Standard;
@@ -12,9 +14,11 @@ use utoipa::ToSchema;
 )]
 #[schema(as = models::file::metadata::Checksums)]
 pub struct Checksums {
-    /// The namespace of the identifier.
-    #[schema(example = "example-organization")]
+    /// An md5 checksum.
+    #[schema(example = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")]
     md5: Option<cde::v1::file::checksum::MD5>,
+    // NOTE: if more checksums are added here, they also need to be added to the
+    // `as_map()` function below.
 }
 
 impl Checksums {
@@ -53,6 +57,35 @@ impl Checksums {
     /// ```
     pub fn md5(&self) -> Option<&cde::v1::file::checksum::MD5> {
         self.md5.as_ref()
+    }
+
+    /// Gets the checksums as a [`HashMap`] where the key is the algorithm name
+    /// and the values are the (optional) checksum values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_cde as cde;
+    /// use ccdi_models as models;
+    ///
+    /// let checksums = models::file::metadata::Checksums::new(Some(
+    ///     cde::v1::file::checksum::MD5::try_new("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap(),
+    /// ));
+    ///
+    /// let map = checksums.as_map();
+    /// assert_eq!(
+    ///     map.get("md5").unwrap().as_str(),
+    ///     "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    /// );
+    /// ```
+    pub fn as_map(&self) -> HashMap<String, String> {
+        let mut map = HashMap::new();
+
+        if let Some(checksum) = &self.md5 {
+            map.insert(String::from("md5"), checksum.to_string());
+        }
+
+        map
     }
 }
 

--- a/packages/ccdi-server/src/filter.rs
+++ b/packages/ccdi-server/src/filter.rs
@@ -6,6 +6,7 @@ use ccdi_models as models;
 
 use models::Entity;
 
+pub mod file;
 pub mod sample;
 pub mod subject;
 
@@ -176,6 +177,13 @@ where
             introspect::Member::Field(field) => field.identifier().unwrap().to_string(),
             // SAFETY: parameters will never be expressed as an `enum`.
             introspect::Member::Variant(_) => unreachable!(),
+        };
+
+        // If the field starts with `r#`, strip that, as it is an artifact of
+        // Rust.
+        let field = match field.starts_with("r#") {
+            true => field.strip_prefix("r#").unwrap().to_string(),
+            false => field,
         };
 
         entities = entities.filter_metadata_field(field, &filter_params);

--- a/packages/ccdi-server/src/filter/file.rs
+++ b/packages/ccdi-server/src/filter/file.rs
@@ -1,0 +1,80 @@
+//! Filter parameters for [`File`]s.
+
+use ccdi_models as models;
+
+use models::File;
+
+use crate::filter::FilterMetadataField;
+use crate::params::filter::File as FilterFileParams;
+
+impl FilterMetadataField<File, FilterFileParams> for Vec<File> {
+    fn filter_metadata_field(self, field: String, params: &FilterFileParams) -> Vec<File> {
+        let parameter = match field.as_str() {
+            "type" => params.r#type.as_ref(),
+            "size" => params.size.as_ref(),
+            "checksums" => params.checksums.as_ref(),
+            "description" => params.description.as_ref(),
+            _ => unreachable!("unhandled file metadata field: {field}"),
+        };
+
+        let query = match parameter {
+            Some(query) => query,
+            // If the parameter has no value, just return the original list of
+            // files, as the user does not want to filter based on that.
+            None => return self,
+        };
+
+        self.into_iter()
+            .filter(|file| {
+                if field.as_str() == "description" {
+                    if let Some(metadata) = file.metadata() {
+                        if let Some(description) = metadata.description() {
+                            // Only return the entry if the query is a substring
+                            // of the description.
+                            return description.to_string().contains(query);
+                        }
+
+                        // If the metadata doesn't have a description, the entry
+                        // should not be included.
+                        return false;
+                    }
+
+                    // If no metadata is included, this entry should not be
+                    // included.
+                    false
+                } else {
+                    // All other "non-description" fields.
+                    let values: Option<Vec<String>> = match field.as_str() {
+                        "type" => file
+                            .metadata()
+                            .and_then(|metadata| metadata.r#type())
+                            .map(|r#type| vec![r#type.to_string()]),
+                        "size" => file
+                            .metadata()
+                            .and_then(|metadata| metadata.size())
+                            .map(|size| vec![size.to_string()]),
+                        "checksums" => file
+                            .metadata()
+                            .and_then(|metadata| metadata.checksums())
+                            .map(|checksums| {
+                                checksums
+                                    .value()
+                                    .as_map()
+                                    .into_values()
+                                    .map(|r| r.to_string())
+                                    .collect::<Vec<String>>()
+                            }),
+                        _ => unreachable!("unhandled file metadata field: {field}"),
+                    };
+
+                    match values {
+                        Some(values) => values.into_iter().any(|s| s.eq(query)),
+                        // Files with no values for this field are automatically
+                        // filtered as described in the rules for filtering.
+                        None => false,
+                    }
+                }
+            })
+            .collect::<Vec<_>>()
+    }
+}

--- a/packages/ccdi-server/src/paginate.rs
+++ b/packages/ccdi-server/src/paginate.rs
@@ -25,6 +25,11 @@ where
     R: Serialize,
     R: From<(Vec<T>, usize)>,
 {
+    if all_entities.is_empty() {
+        // If there are no entities to return, just return an empty array back.
+        return HttpResponse::Ok().json(Vec::<R>::new());
+    }
+
     let page = match NonZeroUsize::try_from(params.page().unwrap_or(pagination::DEFAULT_PAGE)) {
         Ok(value) => value,
         Err(_) => {
@@ -49,13 +54,6 @@ where
                 ))
             }
         };
-
-    if all_entities.is_empty() {
-        // If this error occurs, there is likely some misconfiguration that
-        // allows zero entities to be generated for the server. This should be
-        // caught before we get to this point and reported to the user.
-        panic!("there must be at least one entity to paginate.");
-    }
 
     let pages = all_entities.chunks(per_page.get()).collect::<Vec<_>>();
 

--- a/packages/ccdi-server/src/params/filter.rs
+++ b/packages/ccdi-server/src/params/filter.rs
@@ -21,8 +21,8 @@ pub struct Subject {
     #[param(required = false, nullable = false)]
     pub sex: Option<String>,
 
-    /// Matches any subject where any member of the `race` fieldmatches
-    /// the string provided.
+    /// Matches any subject where any member of the `race` fieldmatches the
+    /// string provided.
     ///
     /// **Note:** a logical OR (`||`) is performed across the values when
     /// determining whether the subject should be included in the results.
@@ -30,7 +30,8 @@ pub struct Subject {
     #[param(required = false, nullable = false)]
     pub race: Option<String>,
 
-    /// Matches any subject where the `ethnicity` field matches the string provided.
+    /// Matches any subject where the `ethnicity` field matches the string
+    /// provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[param(required = false, nullable = false)]
     pub ethnicity: Option<String>,
@@ -44,22 +45,24 @@ pub struct Subject {
     #[param(required = false, nullable = false)]
     pub identifiers: Option<String>,
 
-    /// Matches any subject where the `vital_status` field matches the string provided.
+    /// Matches any subject where the `vital_status` field matches the string
+    /// provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[param(required = false, nullable = false)]
     pub vital_status: Option<String>,
 
-    /// Matches any subject where the `age_at_vital_status` field matches the string provided.
+    /// Matches any subject where the `age_at_vital_status` field matches the
+    /// string provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[param(required = false, nullable = false)]
     pub age_at_vital_status: Option<String>,
 }
 
-/// Parameters for filtering subjects.
+/// Parameters for filtering samples.
 ///
 /// None of the parameters are required, but they may be provided as a
 /// [`String`]. When a parameter is provided, the endpoint will filter the
-/// results to only include [`Subject`]s where the value for the key exactly
+/// results to only include [`Sample`]s where the value for the key exactly
 /// matches the value provided for the parameter (i.e., matching is done by
 /// looking for the provided parameter as a substring). Matches are
 /// case-sensitive.
@@ -84,18 +87,61 @@ pub struct Sample {
     #[param(required = false, nullable = false)]
     pub tumor_classification: Option<String>,
 
-    /// Matches any sample where the `age_at_diagnosis` field matches the string provided.
+    /// Matches any sample where the `age_at_diagnosis` field matches the string
+    /// provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[param(required = false, nullable = false)]
     pub age_at_diagnosis: Option<String>,
 
-    /// Matches any sample where the `age_at_collection` field matches the string provided.
+    /// Matches any sample where the `age_at_collection` field matches the
+    /// string provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[param(required = false, nullable = false)]
     pub age_at_collection: Option<String>,
 
-    /// Matches any sample where the `tumor_tissue_morphology` field matches the string provided.
+    /// Matches any sample where the `tumor_tissue_morphology` field matches the
+    /// string provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[param(required = false, nullable = false)]
     pub tumor_tissue_morphology: Option<String>,
+}
+
+/// Parameters for filtering files.
+///
+/// None of the parameters are required, but they may be provided as a
+/// [`String`]. When a parameter is provided, the endpoint will filter the
+/// results to only include [`File`]s where the value for the key exactly
+/// matches the value provided for the parameter (i.e., matching is done by
+/// looking for the provided parameter as a substring). Matches are
+/// case-sensitive.
+#[derive(Debug, Default, Deserialize, IntoParams, Introspect, Serialize)]
+#[into_params(parameter_in = Query)]
+pub struct File {
+    /// Matches any file where the `type` field matches the string provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub r#type: Option<String>,
+
+    /// Matches any file where the `size` field matches the string provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub size: Option<String>,
+
+    /// Matches any file where the `checksums` field matches the string
+    /// provided.
+    ///
+    /// **Note:** a logical OR (`||`) is performed across the values when
+    /// determining whether the file should be included in the results.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub checksums: Option<String>,
+
+    /// Matches any file where the `description` field matches the string
+    /// provided.
+    ///
+    /// **Note:** a file is returned if the value provided is a substring of the
+    /// description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub description: Option<String>,
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -321,8 +321,8 @@ paths:
       - name: race
         in: query
         description: |-
-          Matches any subject where any member of the `race` fieldmatches
-          the string provided.
+          Matches any subject where any member of the `race` fieldmatches the
+          string provided.
 
           **Note:** a logical OR (`||`) is performed across the values when
           determining whether the subject should be included in the results.
@@ -331,7 +331,9 @@ paths:
           type: string
       - name: ethnicity
         in: query
-        description: Matches any subject where the `ethnicity` field matches the string provided.
+        description: |-
+          Matches any subject where the `ethnicity` field matches the string
+          provided.
         required: false
         schema:
           type: string
@@ -348,13 +350,17 @@ paths:
           type: string
       - name: vital_status
         in: query
-        description: Matches any subject where the `vital_status` field matches the string provided.
+        description: |-
+          Matches any subject where the `vital_status` field matches the string
+          provided.
         required: false
         schema:
           type: string
       - name: age_at_vital_status
         in: query
-        description: Matches any subject where the `age_at_vital_status` field matches the string provided.
+        description: |-
+          Matches any subject where the `age_at_vital_status` field matches the
+          string provided.
         required: false
         schema:
           type: string
@@ -602,19 +608,25 @@ paths:
           type: string
       - name: age_at_diagnosis
         in: query
-        description: Matches any sample where the `age_at_diagnosis` field matches the string provided.
+        description: |-
+          Matches any sample where the `age_at_diagnosis` field matches the string
+          provided.
         required: false
         schema:
           type: string
       - name: age_at_collection
         in: query
-        description: Matches any sample where the `age_at_collection` field matches the string provided.
+        description: |-
+          Matches any sample where the `age_at_collection` field matches the
+          string provided.
         required: false
         schema:
           type: string
       - name: tumor_tissue_morphology
         in: query
-        description: Matches any sample where the `tumor_tissue_morphology` field matches the string provided.
+        description: |-
+          Matches any sample where the `tumor_tissue_morphology` field matches the
+          string provided.
         required: false
         schema:
           type: string
@@ -815,6 +827,53 @@ paths:
         in the `responses::Files` schema.
       operationId: file_index
       parameters:
+      - name: type
+        in: query
+        description: Matches any file where the `type` field matches the string provided.
+        required: false
+        schema:
+          type: string
+      - name: size
+        in: query
+        description: Matches any file where the `size` field matches the string provided.
+        required: false
+        schema:
+          type: string
+      - name: checksums
+        in: query
+        description: |-
+          Matches any file where the `checksums` field matches the string
+          provided.
+
+          **Note:** a logical OR (`||`) is performed across the values when
+          determining whether the file should be included in the results.
+        required: false
+        schema:
+          type: string
+      - name: description
+        in: query
+        description: |-
+          Matches any file where the `description` field matches the string
+          provided.
+
+          **Note:** a file is returned if the value provided is a substring of the
+          description.
+        required: false
+        schema:
+          type: string
+      - name: metadata.unharmonized.<field>
+        in: query
+        description: |-
+          All unharmonized fields should be filterable in the same manner as harmonized fields:
+
+          * Filtering on a singular field should include the `File` in the results if the query exactly matches the value of that field for the `File` (case-sensitive).
+          * Filtering on field with multiple values should include the `File` in the results if the query exactly matches any of the values of the field for that `File` (case-sensitive).
+          * Unlike harmonized fields, unharmonized fields must be prefixed with `metadata.unharmonized`.
+
+          **Note:** this query parameter is intended to be symbolic of any unharmonized field. Because of limitations within Swagger UI, it will show up as a query parameter that can be optionally be submitted as part of a request within Swagger UI. Please keep in mind that the literal query parameter `?metadata.unharmonized.<field>=value` is not supported, so attempting to use it within Swagger UI will not work!
+        required: false
+        schema:
+          type: string
       - name: page
         in: query
         description: |-


### PR DESCRIPTION
**PR Close Date:** April 19, 2024

This PR adds erroneously missing filtering capabilities to the `/file` endpoint. These appear to have just been missed when I implemented files.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added a line describing the change in the `CHANGELOG.md` under `[Unreleased]`.
