### PR TITLE
feat: adds harmonization details to metadata assignments

### DIFF
--- a/.styles/config/vocabularies/CCDI/accept.txt
+++ b/.styles/config/vocabularies/CCDI/accept.txt
@@ -3,3 +3,7 @@
 (?i)namespaces?
 (?i)pseudocode
 CDEs?
+ontology
+ontologies
+
+age_at_collection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/metadata/file/fields` ([link to
   card](https://github.com/orgs/CBIIT/projects/19?pane=issue&itemId=56853672),
   [#82](https://github.com/CBIIT/ccdi-federation-api/pull/82)).
-- Two new metadata elements were added for samples ([link to card](https://github.com/orgs/CBIIT/projects/19?pane=issue&itemId=56853844), [#89](https://github.com/CBIIT/ccdi-federation-api/pull/89)).
-  - The library strategy for the sample (CDE 6273393 v1.00, [#48](https://github.com/CBIIT/ccdi-federation-api/discussions/48))
-  - The preservation method for the sample's biospecimen (CDE 8028962 v2.00, [#64](https://github.com/CBIIT/ccdi-federation-api/discussions/64))
+- Two new metadata elements were added for samples ([link to
+  card](https://github.com/orgs/CBIIT/projects/19?pane=issue&itemId=56853844),
+  [#89](https://github.com/CBIIT/ccdi-federation-api/pull/89)).
+  - The library strategy for the sample (CDE 6273393 v1.00,
+    [#48](https://github.com/CBIIT/ccdi-federation-api/discussions/48))
+  - The preservation method for the sample's biospecimen (CDE 8028962 v2.00,
+    [#64](https://github.com/CBIIT/ccdi-federation-api/discussions/64))
+- Adds optional details facilities for harmonization value assignments ([link to
+  card](https://github.com/orgs/CBIIT/projects/19?pane=issue&itemId=59589170),
+  [#90](https://github.com/CBIIT/ccdi-federation-api/pull/90)).
 
 ### Changed
 

--- a/packages/ccdi-models/src/file/metadata.rs
+++ b/packages/ccdi-models/src/file/metadata.rs
@@ -53,7 +53,7 @@ impl Metadata {
     /// use models::file::metadata::Builder;
     /// use models::metadata::field::unowned::file::Type;
     ///
-    /// let field = Type::new(cde::v1::file::Type::TXT, None, None);
+    /// let field = Type::new(cde::v1::file::Type::TXT, None, None, None);
     /// let metadata = Builder::default().r#type(field).build();
     ///
     /// assert_eq!(
@@ -76,7 +76,7 @@ impl Metadata {
     /// use models::file::metadata::Builder;
     /// use models::metadata::field::unowned::file::Size;
     ///
-    /// let field = Size::new(cde::v1::file::Size::new(42), None, None);
+    /// let field = Size::new(cde::v1::file::Size::new(42), None, None, None);
     /// let metadata = Builder::default().size(field).build();
     ///
     /// assert_eq!(
@@ -104,6 +104,7 @@ impl Metadata {
     ///     models::file::metadata::Checksums::new(Some(md5)),
     ///     None,
     ///     None,
+    ///     None,
     /// );
     /// let metadata = Builder::default().checksums(field).build();
     ///
@@ -129,6 +130,7 @@ impl Metadata {
     ///
     /// let field = Description::new(
     ///     cde::v1::file::Description::new("This is a description."),
+    ///     None,
     ///     None,
     ///     None,
     /// );
@@ -165,12 +167,14 @@ impl Metadata {
     ///             Value::String("test".into()),
     ///             None,
     ///             None,
+    ///             None,
     ///         )),
     ///     )
     ///     .insert_unharmonized(
     ///         "owned",
     ///         UnharmonizedField::Owned(owned::Field::new(
     ///             Value::String("test".into()),
+    ///             None,
     ///             None,
     ///             None,
     ///             None,
@@ -210,15 +214,18 @@ impl Metadata {
                 cde::v1::file::Type::TXT,
                 None,
                 None,
+                None,
             )),
             size: Some(field::unowned::file::Size::new(
                 cde::v1::file::Size::new(rand::thread_rng().gen_range(usize::MIN..=usize::MAX)),
+                None,
                 None,
                 None,
             )),
             checksums: Some(rand::random()),
             description: Some(field::unowned::file::Description::new(
                 cde::v1::file::Description::new("This is an example description."),
+                None,
                 None,
                 None,
             )),

--- a/packages/ccdi-models/src/file/metadata/builder.rs
+++ b/packages/ccdi-models/src/file/metadata/builder.rs
@@ -35,7 +35,7 @@ impl Builder {
     /// use models::file::metadata::Builder;
     /// use models::metadata::field::unowned::file::Type;
     ///
-    /// let field = Type::new(cde::v1::file::Type::TXT, None, None);
+    /// let field = Type::new(cde::v1::file::Type::TXT, None, None, None);
     /// let builder = Builder::default().r#type(field);
     /// ```
     pub fn r#type(mut self, field: field::unowned::file::Type) -> Self {
@@ -54,7 +54,7 @@ impl Builder {
     /// use models::file::metadata::Builder;
     /// use models::metadata::field::unowned::file::Size;
     ///
-    /// let field = Size::new(cde::v1::file::Size::new(42), None, None);
+    /// let field = Size::new(cde::v1::file::Size::new(42), None, None, None);
     /// let builder = Builder::default().size(field);
     /// ```
     pub fn size(mut self, field: field::unowned::file::Size) -> Self {
@@ -78,6 +78,7 @@ impl Builder {
     ///     models::file::metadata::Checksums::new(Some(md5)),
     ///     None,
     ///     None,
+    ///     None,
     /// );
     /// let builder = Builder::default().checksums(field);
     /// ```
@@ -99,6 +100,7 @@ impl Builder {
     ///
     /// let field = Description::new(
     ///     cde::v1::file::Description::new("This is a description."),
+    ///     None,
     ///     None,
     ///     None,
     /// );
@@ -132,12 +134,14 @@ impl Builder {
     ///             Value::String("test".into()),
     ///             None,
     ///             None,
+    ///             None,
     ///         )),
     ///     )
     ///     .insert_unharmonized(
     ///         "owned",
     ///         UnharmonizedField::Owned(owned::Field::new(
     ///             Value::String("test".into()),
+    ///             None,
     ///             None,
     ///             None,
     ///             None,

--- a/packages/ccdi-models/src/metadata/field.rs
+++ b/packages/ccdi-models/src/metadata/field.rs
@@ -6,10 +6,12 @@ use utoipa::ToSchema;
 
 pub mod description;
 
+pub mod details;
 pub mod owned;
 pub mod unowned;
 
 pub use description::Description;
+pub use details::Details;
 
 use crate::metadata::field;
 

--- a/packages/ccdi-models/src/metadata/field/details.rs
+++ b/packages/ccdi-models/src/metadata/field/details.rs
@@ -1,0 +1,143 @@
+//! Details pertaining to a specific harmonized value.
+
+mod harmonizer;
+mod method;
+
+pub use harmonizer::Harmonizer;
+pub use method::Method;
+
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use crate::Url;
+
+/// Details regarding the harmonization process.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema)]
+#[schema(as = models::metadata::field::Details)]
+pub struct Details {
+    /// The method by which the data was harmonized.
+    #[schema(value_type = Option<models::metadata::field::details::Method>)]
+    method: Option<Method>,
+
+    /// The type of individual (or individuals) that harmonized the data.
+    #[schema(value_type = Option<models::metadata::field::details::Harmonizer>)]
+    harmonizer: Option<Harmonizer>,
+
+    /// An optional URL at which you can learn more specific details about the
+    /// considerations for this harmonized value.
+    #[schema(value_type = Option<models::Url>)]
+    url: Option<Url>,
+}
+
+impl Details {
+    /// Creates a new [`Details`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_models as models;
+    ///
+    /// use models::metadata::field::details::Harmonizer;
+    /// use models::metadata::field::details::Method;
+    /// use models::metadata::field::Details;
+    /// use models::Url;
+    ///
+    /// let details = Details::new(
+    ///     Some(Method::Mapped),
+    ///     Some(Harmonizer::DomainExpert),
+    ///     Some(Url::from(
+    ///         url::Url::try_from("https://hello.world/").unwrap(),
+    ///     )),
+    /// );
+    ///
+    /// assert_eq!(details.method(), Some(&Method::Mapped));
+    /// assert_eq!(details.harmonizer(), Some(&Harmonizer::DomainExpert));
+    /// assert_eq!(details.url().unwrap().as_str(), "https://hello.world/");
+    /// ```
+    pub fn new(method: Option<Method>, harmonizer: Option<Harmonizer>, url: Option<Url>) -> Self {
+        Self {
+            method,
+            harmonizer,
+            url,
+        }
+    }
+
+    /// Gets the [`Method`] from the [`Details`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_models as models;
+    ///
+    /// use models::metadata::field::details::Harmonizer;
+    /// use models::metadata::field::details::Method;
+    /// use models::metadata::field::Details;
+    /// use models::Url;
+    ///
+    /// let details = Details::new(
+    ///     Some(Method::Mapped),
+    ///     Some(Harmonizer::DomainExpert),
+    ///     Some(Url::from(
+    ///         url::Url::try_from("https://hello.world/").unwrap(),
+    ///     )),
+    /// );
+    ///
+    /// assert_eq!(details.method(), Some(&Method::Mapped));
+    /// ```
+    pub fn method(&self) -> Option<&Method> {
+        self.method.as_ref()
+    }
+
+    /// Gets the [`Harmonizer`] from the [`Details`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_models as models;
+    ///
+    /// use models::metadata::field::details::Harmonizer;
+    /// use models::metadata::field::details::Method;
+    /// use models::metadata::field::Details;
+    /// use models::Url;
+    ///
+    /// let details = Details::new(
+    ///     Some(Method::Mapped),
+    ///     Some(Harmonizer::DomainExpert),
+    ///     Some(Url::from(
+    ///         url::Url::try_from("https://hello.world/").unwrap(),
+    ///     )),
+    /// );
+    ///
+    /// assert_eq!(details.harmonizer(), Some(&Harmonizer::DomainExpert));
+    /// ```
+    pub fn harmonizer(&self) -> Option<&Harmonizer> {
+        self.harmonizer.as_ref()
+    }
+
+    /// Gets the [`Harmonizer`] from the [`Details`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_models as models;
+    ///
+    /// use models::metadata::field::details::Harmonizer;
+    /// use models::metadata::field::details::Method;
+    /// use models::metadata::field::Details;
+    /// use models::Url;
+    ///
+    /// let details = Details::new(
+    ///     Some(Method::Mapped),
+    ///     Some(Harmonizer::DomainExpert),
+    ///     Some(Url::from(
+    ///         url::Url::try_from("https://hello.world/").unwrap(),
+    ///     )),
+    /// );
+    ///
+    /// assert_eq!(details.url().unwrap().as_str(), "https://hello.world/");
+    /// ```
+    pub fn url(&self) -> Option<&Url> {
+        self.url.as_ref()
+    }
+}

--- a/packages/ccdi-models/src/metadata/field/details/harmonizer.rs
+++ b/packages/ccdi-models/src/metadata/field/details/harmonizer.rs
@@ -1,0 +1,29 @@
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// A statement on the expertise of the individual (or individuals) who are
+/// assigning the harmonized values. This information can help data receivers
+/// understand the context within which the data was harmonized (particularly in
+/// data fields that may be constantly evolving or changing—for instance,
+/// diagnosis).
+///
+/// **NOTE:** if you find that there are types of harmonizers that are not
+/// captured here, please make an issue on the GitHub repository so we can
+/// support the value.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema)]
+#[schema(as = models::metadata::field::details::Harmonizer)]
+pub enum Harmonizer {
+    /// An individual who is reputed to be an expert in the domain of the
+    /// harmonized value and the data source itself. Typically, these
+    /// individuals are involved on the project from whence the data was
+    /// generated.
+    DomainExpert,
+
+    /// An individual on the data curation team for the source server. These
+    /// individuals are generally knowledgable about the subject area but, at
+    /// times, lack context particular to the project itself. They are generally
+    /// _not_ reputed to be an expert in the domain of the harmonized value and
+    /// the data source itself
+    CurationTeamMember,
+}

--- a/packages/ccdi-models/src/metadata/field/details/method.rs
+++ b/packages/ccdi-models/src/metadata/field/details/method.rs
@@ -1,0 +1,18 @@
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// The method by which data was harmonized.
+///
+/// **NOTE:** if you find that there are types of harmonization methods that are
+/// not captured here, please make an issue on the GitHub repository so we can
+/// support the value.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema)]
+#[schema(as = models::metadata::field::details::Method)]
+pub enum Method {
+    /// The data was mapped from its form at the source to match the harmonized
+    /// term. This value represents ideas like translating between two diagnosis
+    /// ontologies or manually categorizing a free-text field to a controlled
+    /// vocabulary.
+    Mapped,
+}

--- a/packages/ccdi-models/src/metadata/fields.rs
+++ b/packages/ccdi-models/src/metadata/fields.rs
@@ -60,6 +60,7 @@ impl Unharmonized {
     ///         Value::String("world".into()),
     ///         None,
     ///         None,
+    ///         None,
     ///     )),
     /// );
     /// ```
@@ -149,6 +150,7 @@ mod tests {
                 Value::String(String::from("world")),
                 None,
                 None,
+                None,
             )),
         );
 
@@ -156,6 +158,7 @@ mod tests {
             String::from("foo"),
             UnharmonizedField::Owned(owned::Field::new(
                 Value::String(String::from("bar")),
+                None,
                 None,
                 None,
                 Some(true),

--- a/packages/ccdi-models/src/sample/metadata.rs
+++ b/packages/ccdi-models/src/sample/metadata.rs
@@ -87,6 +87,7 @@ impl Metadata {
     ///         models::sample::metadata::AgeAtDiagnosis::from(OrderedFloat(365.25)),
     ///         None,
     ///         None,
+    ///         None,
     ///     ))
     ///     .build();
     ///
@@ -94,6 +95,7 @@ impl Metadata {
     ///     metadata.age_at_diagnosis(),
     ///     Some(&AgeAtDiagnosis::new(
     ///         models::sample::metadata::AgeAtDiagnosis::from(OrderedFloat(365.25)),
+    ///         None,
     ///         None,
     ///         None
     ///     ))
@@ -119,6 +121,7 @@ impl Metadata {
     ///         cde::v1::sample::DiseasePhase::InitialDiagnosis,
     ///         None,
     ///         None,
+    ///         None,
     ///     ))
     ///     .build();
     ///
@@ -126,6 +129,7 @@ impl Metadata {
     ///     metadata.disease_phase(),
     ///     Some(&DiseasePhase::new(
     ///         cde::v1::sample::DiseasePhase::InitialDiagnosis,
+    ///         None,
     ///         None,
     ///         None
     ///     ))
@@ -151,6 +155,7 @@ impl Metadata {
     ///         cde::v1::sample::LibraryStrategy::RnaSeq,
     ///         None,
     ///         None,
+    ///         None,
     ///     ))
     ///     .build();
     ///
@@ -159,7 +164,8 @@ impl Metadata {
     ///     Some(&LibraryStrategy::new(
     ///         cde::v1::sample::LibraryStrategy::RnaSeq,
     ///         None,
-    ///         None
+    ///         None,
+    ///         None,
     ///     ))
     /// );
     /// ```
@@ -183,6 +189,7 @@ impl Metadata {
     ///         cde::v2::sample::PreservationMethod::Ffpe,
     ///         None,
     ///         None,
+    ///         None,
     ///     ))
     ///     .build();
     ///
@@ -191,7 +198,8 @@ impl Metadata {
     ///     Some(&PreservationMethod::new(
     ///         cde::v2::sample::PreservationMethod::Ffpe,
     ///         None,
-    ///         None
+    ///         None,
+    ///         None,
     ///     ))
     /// );
     /// ```
@@ -215,6 +223,7 @@ impl Metadata {
     ///         cde::v2::sample::TissueType::Tumor,
     ///         None,
     ///         None,
+    ///         None,
     ///     ))
     ///     .build();
     ///
@@ -222,6 +231,7 @@ impl Metadata {
     ///     metadata.tissue_type(),
     ///     Some(&TissueType::new(
     ///         cde::v2::sample::TissueType::Tumor,
+    ///         None,
     ///         None,
     ///         None
     ///     ))
@@ -247,6 +257,7 @@ impl Metadata {
     ///         cde::v1::sample::TumorClassification::Primary,
     ///         None,
     ///         None,
+    ///         None,
     ///     ))
     ///     .build();
     ///
@@ -254,6 +265,7 @@ impl Metadata {
     ///     metadata.tumor_classification(),
     ///     Some(&TumorClassification::new(
     ///         cde::v1::sample::TumorClassification::Primary,
+    ///         None,
     ///         None,
     ///         None
     ///     ))
@@ -279,6 +291,7 @@ impl Metadata {
     ///         cde::v1::sample::TumorTissueMorphology::from(String::from("8010/0")),
     ///         None,
     ///         None,
+    ///         None,
     ///     ))
     ///     .build();
     ///
@@ -286,6 +299,7 @@ impl Metadata {
     ///     metadata.tumor_tissue_morphology(),
     ///     Some(&TumorTissueMorphology::new(
     ///         cde::v1::sample::TumorTissueMorphology::from(String::from("8010/0")),
+    ///         None,
     ///         None,
     ///         None
     ///     ))
@@ -313,6 +327,7 @@ impl Metadata {
     ///         models::sample::metadata::AgeAtCollection::from(OrderedFloat(365.25)),
     ///         None,
     ///         None,
+    ///         None,
     ///     ))
     ///     .build();
     ///
@@ -320,6 +335,7 @@ impl Metadata {
     ///     metadata.age_at_collection(),
     ///     Some(&AgeAtCollection::new(
     ///         models::sample::metadata::AgeAtCollection::from(OrderedFloat(365.25)),
+    ///         None,
     ///         None,
     ///         None
     ///     ))
@@ -372,7 +388,7 @@ impl Metadata {
     ///     ),
     /// );
     ///
-    /// let field = Identifier::new(sample_id, None, None);
+    /// let field = Identifier::new(sample_id, None, None, None);
     /// let metadata = Builder::default().append_identifier(field.clone()).build();
     ///
     /// assert_eq!(metadata.identifiers(), Some(&vec![field]));
@@ -403,12 +419,14 @@ impl Metadata {
     ///             Value::String("test".into()),
     ///             None,
     ///             None,
+    ///             None,
     ///         )),
     ///     )
     ///     .insert_unharmonized(
     ///         "owned",
     ///         UnharmonizedField::Owned(owned::Field::new(
     ///             Value::String("test".into()),
+    ///             None,
     ///             None,
     ///             None,
     ///             None,
@@ -477,6 +495,7 @@ impl Metadata {
                 crate::sample::metadata::AgeAtDiagnosis::from(OrderedFloat(365.25)),
                 None,
                 None,
+                None,
             )),
             disease_phase: rand::random(),
             library_strategy: rand::random(),
@@ -488,9 +507,11 @@ impl Metadata {
                 ccdi_cde::v1::sample::TumorTissueMorphology::from(String::from("8000/0")),
                 None,
                 None,
+                None,
             )),
             age_at_collection: Some(field::unowned::sample::AgeAtCollection::new(
                 crate::sample::metadata::AgeAtCollection::from(OrderedFloat(365.25)),
+                None,
                 None,
                 None,
             )),
@@ -506,6 +527,7 @@ impl Metadata {
                     ),
                     None,
                     None,
+                    None,
                 ),
                 field::unowned::sample::Identifier::new(
                     crate::sample::identifier::referenced::Identifier::Unlinked(
@@ -516,6 +538,7 @@ impl Metadata {
                                 .collect::<String>()
                         )),
                     ),
+                    None,
                     None,
                     None,
                 ),

--- a/packages/ccdi-models/src/sample/metadata/builder.rs
+++ b/packages/ccdi-models/src/sample/metadata/builder.rs
@@ -55,6 +55,7 @@ impl Builder {
     ///     models::sample::metadata::AgeAtDiagnosis::from(OrderedFloat(365.25)),
     ///     None,
     ///     None,
+    ///     None,
     /// );
     /// let builder = Builder::default().age_at_diagnosis(field);
     /// ```
@@ -74,7 +75,12 @@ impl Builder {
     /// use models::metadata::field::unowned::sample::DiseasePhase;
     /// use models::sample::metadata::Builder;
     ///
-    /// let field = DiseasePhase::new(cde::v1::sample::DiseasePhase::InitialDiagnosis, None, None);
+    /// let field = DiseasePhase::new(
+    ///     cde::v1::sample::DiseasePhase::InitialDiagnosis,
+    ///     None,
+    ///     None,
+    ///     None,
+    /// );
     /// let builder = Builder::default().disease_phase(field);
     /// ```
     pub fn disease_phase(mut self, field: field::unowned::sample::DiseasePhase) -> Self {
@@ -93,7 +99,7 @@ impl Builder {
     /// use models::metadata::field::unowned::sample::TissueType;
     /// use models::sample::metadata::Builder;
     ///
-    /// let field = TissueType::new(cde::v2::sample::TissueType::Tumor, None, None);
+    /// let field = TissueType::new(cde::v2::sample::TissueType::Tumor, None, None, None);
     /// let builder = Builder::default().tissue_type(field);
     /// ```
     pub fn tissue_type(mut self, field: field::unowned::sample::TissueType) -> Self {
@@ -112,7 +118,12 @@ impl Builder {
     /// use models::metadata::field::unowned::sample::TumorClassification;
     /// use models::sample::metadata::Builder;
     ///
-    /// let field = TumorClassification::new(cde::v1::sample::TumorClassification::Primary, None, None);
+    /// let field = TumorClassification::new(
+    ///     cde::v1::sample::TumorClassification::Primary,
+    ///     None,
+    ///     None,
+    ///     None,
+    /// );
     /// let builder = Builder::default().tumor_classification(field);
     /// ```
     pub fn tumor_classification(
@@ -136,6 +147,7 @@ impl Builder {
     ///
     /// let field = TumorTissueMorphology::new(
     ///     cde::v1::sample::TumorTissueMorphology::from(String::from("8010/0")),
+    ///     None,
     ///     None,
     ///     None,
     /// );
@@ -164,6 +176,7 @@ impl Builder {
     ///     models::sample::metadata::AgeAtCollection::from(OrderedFloat(365.25)),
     ///     None,
     ///     None,
+    ///     None,
     /// );
     /// let builder = Builder::default().age_at_collection(field);
     /// ```
@@ -182,7 +195,7 @@ impl Builder {
     /// use models::metadata::field::unowned::sample::LibraryStrategy;
     /// use models::sample::metadata::Builder;
     ///
-    /// let field = LibraryStrategy::new(cde::v1::sample::LibraryStrategy::RnaSeq, None, None);
+    /// let field = LibraryStrategy::new(cde::v1::sample::LibraryStrategy::RnaSeq, None, None, None);
     /// let builder = Builder::default().library_strategy(field);
     /// ```
     pub fn library_strategy(mut self, field: field::unowned::sample::LibraryStrategy) -> Self {
@@ -201,7 +214,12 @@ impl Builder {
     /// use models::metadata::field::unowned::sample::PreservationMethod;
     /// use models::sample::metadata::Builder;
     ///
-    /// let field = PreservationMethod::new(cde::v2::sample::PreservationMethod::Unknown, None, None);
+    /// let field = PreservationMethod::new(
+    ///     cde::v2::sample::PreservationMethod::Unknown,
+    ///     None,
+    ///     None,
+    ///     None,
+    /// );
     /// let builder = Builder::default().preservation_method(field);
     /// ```
     pub fn preservation_method(
@@ -255,7 +273,7 @@ impl Builder {
     ///     ),
     /// );
     ///
-    /// let field = Identifier::new(sample_id, None, None);
+    /// let field = Identifier::new(sample_id, None, None, None);
     /// let builder = Builder::default().append_identifier(field);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -292,12 +310,14 @@ impl Builder {
     ///             Value::String("test".into()),
     ///             None,
     ///             None,
+    ///             None,
     ///         )),
     ///     )
     ///     .insert_unharmonized(
     ///         "owned",
     ///         UnharmonizedField::Owned(owned::Field::new(
     ///             Value::String("test".into()),
+    ///             None,
     ///             None,
     ///             None,
     ///             None,

--- a/packages/ccdi-models/src/subject/metadata.rs
+++ b/packages/ccdi-models/src/subject/metadata.rs
@@ -68,12 +68,12 @@ impl Metadata {
     /// use models::subject::metadata::Builder;
     ///
     /// let metadata = Builder::default()
-    ///     .sex(Sex::new(cde::v1::subject::Sex::Female, None, None))
+    ///     .sex(Sex::new(cde::v1::subject::Sex::Female, None, None, None))
     ///     .build();
     ///
     /// assert_eq!(
     ///     metadata.sex(),
-    ///     Some(&Sex::new(cde::v1::subject::Sex::Female, None, None))
+    ///     Some(&Sex::new(cde::v1::subject::Sex::Female, None, None, None))
     /// );
     /// ```
     pub fn sex(&self) -> Option<&field::unowned::subject::Sex> {
@@ -92,12 +92,17 @@ impl Metadata {
     /// use models::subject::metadata::Builder;
     ///
     /// let metadata = Builder::default()
-    ///     .append_race(Race::new(cde::v1::subject::Race::Asian, None, None))
+    ///     .append_race(Race::new(cde::v1::subject::Race::Asian, None, None, None))
     ///     .build();
     ///
     /// assert_eq!(
     ///     metadata.race(),
-    ///     Some(&vec![Race::new(cde::v1::subject::Race::Asian, None, None)])
+    ///     Some(&vec![Race::new(
+    ///         cde::v1::subject::Race::Asian,
+    ///         None,
+    ///         None,
+    ///         None
+    ///     )])
     /// );
     /// ```
     pub fn race(&self) -> Option<&Vec<field::unowned::subject::Race>> {
@@ -120,6 +125,7 @@ impl Metadata {
     ///         cde::v2::subject::Ethnicity::NotHispanicOrLatino,
     ///         None,
     ///         None,
+    ///         None,
     ///     ))
     ///     .build();
     ///
@@ -127,6 +133,7 @@ impl Metadata {
     ///     metadata.ethnicity(),
     ///     Some(&Ethnicity::new(
     ///         cde::v2::subject::Ethnicity::NotHispanicOrLatino,
+    ///         None,
     ///         None,
     ///         None
     ///     ))
@@ -179,7 +186,7 @@ impl Metadata {
     ///     ),
     /// );
     ///
-    /// let field = Identifier::new(subject_id, None, None);
+    /// let field = Identifier::new(subject_id, None, None, None);
     /// let metadata = Builder::default().append_identifier(field.clone()).build();
     ///
     /// assert_eq!(metadata.identifiers(), Some(&vec![field]));
@@ -204,6 +211,7 @@ impl Metadata {
     ///         models::subject::metadata::AgeAtVitalStatus::from(OrderedFloat(365.25)),
     ///         None,
     ///         None,
+    ///         None,
     ///     ))
     ///     .build();
     ///
@@ -211,6 +219,7 @@ impl Metadata {
     ///     metadata.age_at_vital_status(),
     ///     Some(&AgeAtVitalStatus::new(
     ///         models::subject::metadata::AgeAtVitalStatus::from(OrderedFloat(365.25)),
+    ///         None,
     ///         None,
     ///         None
     ///     ))
@@ -236,6 +245,7 @@ impl Metadata {
     ///         cde::v1::subject::VitalStatus::Unknown,
     ///         None,
     ///         None,
+    ///         None,
     ///     ))
     ///     .build();
     ///
@@ -243,6 +253,7 @@ impl Metadata {
     ///     metadata.vital_status(),
     ///     Some(&VitalStatus::new(
     ///         cde::v1::subject::VitalStatus::Unknown,
+    ///         None,
     ///         None,
     ///         None
     ///     ))
@@ -274,12 +285,14 @@ impl Metadata {
     ///             Value::String("test".into()),
     ///             None,
     ///             None,
+    ///             None,
     ///         )),
     ///     )
     ///     .insert_unharmonized(
     ///         "owned",
     ///         UnharmonizedField::Owned(owned::Field::new(
     ///             Value::String("test".into()),
+    ///             None,
     ///             None,
     ///             None,
     ///             None,
@@ -358,6 +371,7 @@ impl Metadata {
                     ),
                     None,
                     None,
+                    None,
                 ),
                 field::unowned::subject::Identifier::new(
                     crate::subject::identifier::referenced::Identifier::Unlinked(
@@ -370,11 +384,13 @@ impl Metadata {
                     ),
                     None,
                     None,
+                    None,
                 ),
             ]),
             vital_status: Some(rand::random()),
             age_at_vital_status: Some(field::unowned::subject::AgeAtVitalStatus::new(
                 crate::subject::metadata::AgeAtVitalStatus::from(OrderedFloat(365.25)),
+                None,
                 None,
                 None,
             )),

--- a/packages/ccdi-models/src/subject/metadata/builder.rs
+++ b/packages/ccdi-models/src/subject/metadata/builder.rs
@@ -41,7 +41,7 @@ impl Builder {
     /// use models::metadata::field::unowned::subject::Sex;
     /// use models::subject::metadata::Builder;
     ///
-    /// let field = Sex::new(cde::v1::subject::Sex::Unknown, None, None);
+    /// let field = Sex::new(cde::v1::subject::Sex::Unknown, None, None, None);
     /// let builder = Builder::default().sex(field);
     /// ```
     pub fn sex(mut self, sex: field::unowned::subject::Sex) -> Self {
@@ -60,7 +60,7 @@ impl Builder {
     /// use models::metadata::field::unowned::subject::Race;
     /// use models::subject::metadata::Builder;
     ///
-    /// let field = Race::new(cde::v1::subject::Race::Unknown, None, None);
+    /// let field = Race::new(cde::v1::subject::Race::Unknown, None, None, None);
     /// let builder = Builder::default().append_race(field);
     /// ```
     pub fn append_race(mut self, race: field::unowned::subject::Race) -> Self {
@@ -83,7 +83,7 @@ impl Builder {
     /// use models::metadata::field::unowned::subject::Ethnicity;
     /// use models::subject::metadata::Builder;
     ///
-    /// let field = Ethnicity::new(cde::v2::subject::Ethnicity::Unknown, None, None);
+    /// let field = Ethnicity::new(cde::v2::subject::Ethnicity::Unknown, None, None, None);
     /// let builder = Builder::default().ethnicity(field);
     /// ```
     pub fn ethnicity(mut self, ethnicity: field::unowned::subject::Ethnicity) -> Self {
@@ -134,7 +134,7 @@ impl Builder {
     ///     ),
     /// );
     ///
-    /// let field = Identifier::new(subject_id, None, None);
+    /// let field = Identifier::new(subject_id, None, None, None);
     /// let builder = Builder::default().append_identifier(field);
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -159,7 +159,7 @@ impl Builder {
     /// use models::metadata::field::unowned::subject::VitalStatus;
     /// use models::subject::metadata::Builder;
     ///
-    /// let field = VitalStatus::new(cde::v1::subject::VitalStatus::Unknown, None, None);
+    /// let field = VitalStatus::new(cde::v1::subject::VitalStatus::Unknown, None, None, None);
     /// let builder = Builder::default().vital_status(field);
     /// ```
     pub fn vital_status(mut self, vital_status: field::unowned::subject::VitalStatus) -> Self {
@@ -180,6 +180,7 @@ impl Builder {
     ///
     /// let field = AgeAtVitalStatus::new(
     ///     models::subject::metadata::AgeAtVitalStatus::from(OrderedFloat(365.25)),
+    ///     None,
     ///     None,
     ///     None,
     /// );
@@ -216,12 +217,14 @@ impl Builder {
     ///             Value::String("test".into()),
     ///             None,
     ///             None,
+    ///             None,
     ///         )),
     ///     )
     ///     .insert_unharmonized(
     ///         "owned",
     ///         UnharmonizedField::Owned(owned::Field::new(
     ///             Value::String("test".into()),
+    ///             None,
     ///             None,
     ///             None,
     ///             None,

--- a/packages/ccdi-openapi/docs/DESCRIPTION.md
+++ b/packages/ccdi-openapi/docs/DESCRIPTION.md
@@ -80,7 +80,7 @@ is needed as a fallback across all data elements.
 `null` values, as present in this specification, represent a lack of assertion
 (or, equivalently, a "decline to comment") by the server. This value should not
 be construed to communicate _any_ content about the field it represents—either
-in affirmation or dissent. Instead, they should be interpretted simply as an
+in affirmation or dissent. Instead, they should be interpreted simply as an
 explicit omission of data that can be updated at any time if new information is
 made available to the source server.
 
@@ -253,3 +253,78 @@ partition primary entities to a set of namespaces under that situation:
 - If your server serves data from various governing bodies spread across
   multiple, independent organizations, you should create multiple namespaces
   backed by multiple organizations.
+
+## Metadata
+
+### Interpreting metadata assignments
+
+Metadata shared through this API is expected to be collected and harmonized
+through a variety of mechanisms by individuals with a wide range of
+backgrounds. In certain cases, communicating the process by which metadata was
+collected and harmonized will be critical to correctly interpreting the
+data—particularly in metadata fields where the permissible values are rapidly
+evolving (for example, diagnosis ontologies).
+
+Within this API, there are two primary ways you can learn about harmonized
+metadata fields: (a) via the appropriate `/metadata/fields/<entity>` endpoint
+and (b) through the `details` key within a harmonized metadata object.
+
+- **For information concerning harmonized metadata values where the information
+  is universally true for all value assignments provided by the server**, the
+  information should be present in the `/metadata/fields/<entity>` endpoint
+  response.
+- **For information concerning harmonized metadata values where the information
+  is specific to a particular value assignment (or subset of value assignments)
+  provided by the server**, the information should be present in the
+  `details` key within the harmonized metadata object.
+
+In general, when information _can_ be included in the
+`/metadata/fields/<entity>` response instead of embedded in `details` keys, it
+should be, as that consolidates the information without repeating it for every
+entity. That said, sometimes it is not possible to make blanket statements
+about all harmonized values for a particular metadata field: when the data
+_cannot_ be included in the `/metadata/fields/<entity>` responses, it should be
+reported under the correct facility within the `details` key of the individual
+harmonized value objects.
+
+#### An illustrative example
+
+Consider an example where there are exactly two datasets, **Dataset A** and
+**Dataset B**, that are both served by a single API server.
+
+**When to store information in `/metadata/fields/<entity>`**
+
+Assume that, for both datasets, the team running the API server received
+[age_at_collection](https://github.com/CBIIT/ccdi-federation-api/wiki/Sample-Metadata-Fields#age_at_collection)
+information _exactly_ as the harmonized data value expects and no further
+curation was required. Here, the metadata values were handled the exact same
+way for all datasets provided by the API server. In these cases, any details
+regarding the harmonization process should be provided via the
+`/metadata/fields/<entity>` endpoint rather than duplicating the information in
+every metadata assignment object in the response.
+
+**When to store information in the `details` key of harmonized metadata values**
+
+Conversely, consider a scenario where the two datasets collected and harmonized
+the values for [tissue
+type](https://github.com/CBIIT/ccdi-federation-api/wiki/Sample-Metadata-Fields#tissue_type)
+in different ways:
+
+- For **Dataset A**, assume the team running the API server received values
+  aligned to the harmonized value list, and no further curation was required.
+- For **Dataset B**, assume the team running the API server had to manually
+  curate the mappings between the data they received to the harmonized values.
+
+In this case, no universal statement can be made about the process by which the
+data was harmonized for the tissue type field. As such, no universal statement
+can be made about the harmonization process in `/metadata/fields/<entity>`.
+Instead, details regarding the harmonization process for these values should be
+included directly in the `details` key of each of the metadata value assignment
+objects.
+
+#### A final note on harmonization details
+
+Note that an API server is not _required_ to provide harmonization details for
+any of the harmonized metadata it provides. This mechanism is simply available
+to include information that is deemed contextually relevant at the discretion of
+the curation team.

--- a/packages/ccdi-openapi/src/api.rs
+++ b/packages/ccdi-openapi/src/api.rs
@@ -136,6 +136,11 @@ use utoipa::openapi;
         cde::v1::file::checksum::MD5,
         cde::v1::file::Description,
 
+        // General harmonized field concepts.
+        field::Details,
+        field::details::Harmonizer,
+        field::details::Method,
+
         // Harmonized subject fields.
         field::unowned::subject::Sex,
         field::unowned::subject::Race,

--- a/packages/ccdi-server/src/filter.rs
+++ b/packages/ccdi-server/src/filter.rs
@@ -84,7 +84,7 @@ where
 ///         Kind::Participant,
 ///         Some(
 ///             Builder::default()
-///                 .sex(Sex::new(cde::v1::subject::Sex::Female, None, None))
+///                 .sex(Sex::new(cde::v1::subject::Sex::Female, None, None, None))
 ///                 .build(),
 ///         ),
 ///     ),
@@ -94,8 +94,8 @@ where
 ///         Kind::Participant,
 ///         Some(
 ///             Builder::default()
-///                 .sex(Sex::new(cde::v1::subject::Sex::Female, None, None))
-///                 .append_race(Race::new(cde::v1::subject::Race::Asian, None, None))
+///                 .sex(Sex::new(cde::v1::subject::Sex::Female, None, None, None))
+///                 .append_race(Race::new(cde::v1::subject::Race::Asian, None, None, None))
 ///                 .build(),
 ///         ),
 ///     ),

--- a/packages/ccdi-server/src/params/filter.rs
+++ b/packages/ccdi-server/src/params/filter.rs
@@ -21,7 +21,7 @@ pub struct Subject {
     #[param(required = false, nullable = false)]
     pub sex: Option<String>,
 
-    /// Matches any subject where any member of the `race` fieldmatches the
+    /// Matches any subject where any member of the `race` field matches the
     /// string provided.
     ///
     /// **Note:** a logical OR (`||`) is performed across the values when
@@ -36,7 +36,7 @@ pub struct Subject {
     #[param(required = false, nullable = false)]
     pub ethnicity: Option<String>,
 
-    /// Matches any subject where any member of the `identifiers` fieldmatches
+    /// Matches any subject where any member of the `identifiers` field matches
     /// the string provided.
     ///
     /// **Note:** a logical OR (`||`) is performed across the values when

--- a/swagger.yml
+++ b/swagger.yml
@@ -84,7 +84,7 @@ info:
     `null` values, as present in this specification, represent a lack of assertion
     (or, equivalently, a "decline to comment") by the server. This value should not
     be construed to communicate _any_ content about the field it represents—either
-    in affirmation or dissent. Instead, they should be interpretted simply as an
+    in affirmation or dissent. Instead, they should be interpreted simply as an
     explicit omission of data that can be updated at any time if new information is
     made available to the source server.
 
@@ -257,6 +257,81 @@ info:
     - If your server serves data from various governing bodies spread across
       multiple, independent organizations, you should create multiple namespaces
       backed by multiple organizations.
+
+    ## Metadata
+
+    ### Interpreting metadata assignments
+
+    Metadata shared through this API is expected to be collected and harmonized in
+    a through a variety of mechanisms by individuals with a wide range of
+    backgrounds. In certain cases, communicating the process by which metadata was
+    collected and harmonized will be critical to correctly interpreting the
+    data—particularly in metadata fields where the permissible values are rapidly
+    evolving (for example, diagnosis ontologies).
+
+    Within this API, there are two primary ways you can learn about harmonized
+    metadata fields: (a) via the appropriate `/metadata/fields/<entity>` endpoint
+    and (b) through the `details` key within a harmonized metadata object.
+
+    - **For information concerning harmonized metadata values where the information
+      is universally true for all value assignments provided by the server**, the
+      information should be present in the `/metadata/fields/<entity>` endpoint
+      response.
+    - **For information concerning harmonized metadata values where the information
+      is specific to a particular value assignment (or subset of value assignments)
+      provided by the server**, the information should be present in the
+      `/metadata/fields/<entity>` endpoint response.
+
+    In general, when information _can_ be included in the
+    `/metadata/fields/<entity>` response instead of embedded in `details` keys, it
+    should be, as that consolidates the information without repeating it for every
+    entity. That said, sometimes it is not possible to make blanket statements
+    about all harmonized values for a particular metadata field: when the data
+    _cannot_ be included in the `/metadata/fields/<entity>` responses, it should be
+    reported under the correct facility within the `details` key of the individual
+    harmonized value objects.
+
+    #### An illustrative example
+
+    Consider an example where there are exactly two datasets, **Dataset A** and
+    **Dataset B**, that are both served by a single API server.
+
+    **When to store information in `/metadata/fields/<entity>`**
+
+    Assume that, for both datasets, the team running the API server received
+    [age_at_collection](https://github.com/CBIIT/ccdi-federation-api/wiki/Sample-Metadata-Fields#age_at_collection)
+    information _exactly_ as the harmonized data value expects and no further
+    curation was required. Here, the metadata values were handled the exact same
+    way for all datasets provided by the API server. In these cases, any details
+    regarding the harmonization process should be provided via the
+    `/metadata/fields/<entity>` endpoint rather than duplicating the information in
+    every metadata assignment object in the response.
+
+    **When to store information in the `details` key of harmonized metadata values**
+
+    Conversely, consider a scenario where the two datasets collected and harmonized
+    the values for [tissue
+    type](https://github.com/CBIIT/ccdi-federation-api/wiki/Sample-Metadata-Fields#tissue_type)
+    in different ways:
+
+    - For **Dataset A**, assume the team running the API server received values
+      aligned to the harmonized value list, and no further curation was required.
+    - For **Dataset B**, assume the team running the API server had to manually
+      curate the mappings between the data they received to the harmonized values.
+
+    In this case, no universal statement can be made about the process by which the
+    data was harmonized for the tissue type field. As such, no universal statement
+    can be made about the harmonization process in `/metadata/fields/<entity>`.
+    Instead, details regarding the harmonization process for these values should be
+    included directly in the `details` key of each of the metadata value assignment
+    objects.
+
+    #### A final note on harmonization details
+
+    Note that an API server is not _required_ to provide harmonization details for
+    any of the harmonized metadata it provides. This mechanism is simply available
+    to include information that is deemed contextually relevant at the discretion of
+    the curation team.
   contact:
     name: Childhood Cancer Data Initiative support email
     email: NCIChildhoodCancerDataInitiative@mail.nih.gov
@@ -321,7 +396,7 @@ paths:
       - name: race
         in: query
         description: |-
-          Matches any subject where any member of the `race` fieldmatches the
+          Matches any subject where any member of the `race` field matches the
           string provided.
 
           **Note:** a logical OR (`||`) is performed across the values when
@@ -340,7 +415,7 @@ paths:
       - name: identifiers
         in: query
         description: |-
-          Matches any subject where any member of the `identifiers` fieldmatches
+          Matches any subject where any member of the `identifiers` field matches
           the string provided.
 
           **Note:** a logical OR (`||`) is performed across the values when
@@ -1595,6 +1670,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -1617,6 +1695,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -1636,6 +1717,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -1655,6 +1739,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -1674,6 +1761,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -1693,6 +1783,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -1712,6 +1805,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -1731,6 +1827,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -1750,6 +1849,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -1769,6 +1871,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -1826,6 +1931,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -1845,6 +1953,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -1864,6 +1975,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -1883,6 +1997,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -1902,6 +2019,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -1921,6 +2041,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -1940,6 +2063,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -1959,6 +2085,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -1978,6 +2107,9 @@ components:
 
             Ancestors should be provided as period (`.`) delimited paths
             from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
         comment:
           type: string
           description: A free-text comment field.
@@ -2574,6 +2706,22 @@ components:
       - $ref: '#/components/schemas/models.metadata.field.description.Harmonized'
       - $ref: '#/components/schemas/models.metadata.field.description.Unharmonized'
       description: A description for a metadata field.
+    models.metadata.field.Details:
+      type: object
+      description: Details regarding the harmonization process.
+      properties:
+        method:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.details.Method'
+          nullable: true
+        harmonizer:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.details.Harmonizer'
+          nullable: true
+        url:
+          allOf:
+          - $ref: '#/components/schemas/models.Url'
+          nullable: true
     models.metadata.field.description.Harmonized:
       type: object
       description: |-
@@ -2662,6 +2810,31 @@ components:
           description: The name.
         url:
           $ref: '#/components/schemas/models.Url'
+    models.metadata.field.details.Harmonizer:
+      type: string
+      description: |-
+        A statement on the expertise of the individual (or individuals) who are
+        assigning the harmonized values. This information can help data receivers
+        understand the context within which the data was harmonized (particularly in
+        data fields that may be constantly evolving or changing—for instance,
+        diagnosis).
+
+        **NOTE:** if you find that there are types of harmonizers that are not
+        captured here, please make an issue on the GitHub repository so we can
+        support the value.
+      enum:
+      - DomainExpert
+      - CurationTeamMember
+    models.metadata.field.details.Method:
+      type: string
+      description: |-
+        The method by which data was harmonized.
+
+        **NOTE:** if you find that there are types of harmonization methods that are
+        not captured here, please make an issue on the GitHub repository so we can
+        support the value.
+      enum:
+      - Mapped
     models.namespace.Description:
       type: string
       description: |-


### PR DESCRIPTION
**PR Close Date:** April 24, 2024

This PR introduces the concept of _who_ harmonized a particular data field and _how_ did they harmonize it. In discussion with @GeoffLyle, we both felt like some indication was needed to users regarding the context of how data was harmonized.

- This is an _optional_ part of a harmonized metadata assignment object. As such, you don't have to provide it if you think the assignments were straightforward (e.g., when mapping between simple values). This is really intended to provide a safety valve for fields such as diagnosis and anatomic site where (a) the landscape is rapidly evolving for these metadata fields and (b) the individual curating the data may not be a domain expert and we want to communicate that.
- As you can see, I only included one `Method`: I did this intentionally, as (a) I think it's going to be the most commonly provided value and (b) I tried slicing up other concepts, such as directly copying data from a form, but it got complicated and confusing relatively quickly. As such, I'd rather allow for the discussion from the community to drive design of permissible values for this field.

Last, this means there are now two places to include information about how data was harmonized:

  - In the `/metadata/fields/<entity>` response
  - Embedded in the metadata value assignment object itself under the `details` key.

I address these two options and where information should live between the two in the new "Interpreting assigned values" section of the `DESCRIPTION.md`, so please check that out.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have added a line describing the change in the `CHANGELOG.md` under `[Unreleased]`.
