### PR TITLE
fix: include left-out namespace and org metadata from #91

### DIFF
--- a/packages/ccdi-cde/src/v1/namespace/study_funding_id.rs
+++ b/packages/ccdi-cde/src/v1/namespace/study_funding_id.rs
@@ -17,7 +17,7 @@ use crate::CDE;
 /// Link:
 /// <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=14528051%20and%20ver_nr=1>
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema, Introspect)]
-#[schema(as = cde::v1::namespace::StudyFundingOrganization)]
+#[schema(as = cde::v1::namespace::StudyFundingId)]
 pub struct StudyFundingId(String);
 
 impl From<String> for StudyFundingId {

--- a/packages/ccdi-models/src/namespace.rs
+++ b/packages/ccdi-models/src/namespace.rs
@@ -39,7 +39,7 @@ pub struct Namespace {
 
     /// Harmonized metadata associated with this [`Namespace`].
     #[schema(
-        value_type = Option<models::sample::Metadata>,
+        value_type = Option<models::namespace::Metadata>,
         nullable = true
     )]
     metadata: Option<Metadata>,

--- a/packages/ccdi-models/src/organization.rs
+++ b/packages/ccdi-models/src/organization.rs
@@ -61,7 +61,7 @@ pub struct Organization {
 
     /// Harmonized metadata associated with this [`Organization`].
     #[schema(
-        value_type = Option<models::subject::Metadata>,
+        value_type = Option<models::organization::Metadata>,
         nullable = true
     )]
     metadata: Option<Metadata>,

--- a/packages/ccdi-models/src/organization/metadata.rs
+++ b/packages/ccdi-models/src/organization/metadata.rs
@@ -13,9 +13,9 @@ mod builder;
 
 pub use builder::Builder;
 
-/// Metadata associated with a file.
+/// Metadata associated with an organization.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema)]
-#[schema(as = models::file::Metadata)]
+#[schema(as = models::organization::Metadata)]
 pub struct Metadata {
     /// Institutions associated with an organization.
     ///

--- a/packages/ccdi-openapi/src/api.rs
+++ b/packages/ccdi-openapi/src/api.rs
@@ -142,6 +142,15 @@ use utoipa::openapi;
         cde::v1::file::checksum::MD5,
         cde::v1::file::Description,
 
+        // Harmonized namespace metadata elements.
+        cde::v1::namespace::StudyFundingId,
+        cde::v1::namespace::StudyId,
+        cde::v1::namespace::StudyName,
+        cde::v1::namespace::StudyShortTitle,
+
+        // Harmonized organization metadata elements.
+        cde::v1::organization::Institution,
+
         // Harmonized subject fields.
         field::unowned::subject::Sex,
         field::unowned::subject::Race,
@@ -167,6 +176,15 @@ use utoipa::openapi;
         field::unowned::file::Size,
         field::unowned::file::Checksums,
         field::unowned::file::Description,
+
+        // Harmonized namespace fields.
+        field::unowned::namespace::StudyFundingId,
+        field::unowned::namespace::StudyId,
+        field::unowned::namespace::StudyName,
+        field::unowned::namespace::StudyShortTitle,
+
+        // Harmonized organization fields.
+        field::unowned::organization::Institution,
 
         // Unharmonized fields.
         field::owned::Field,
@@ -215,11 +233,13 @@ use utoipa::openapi;
         models::namespace::identifier::Name,
         models::namespace::Identifier,
         models::namespace::Description,
+        models::namespace::Metadata,
 
         // Organization models.
         models::Organization,
         models::organization::Identifier,
         models::organization::Name,
+        models::organization::Metadata,
 
         // Url model.
         models::Url,

--- a/swagger.yml
+++ b/swagger.yml
@@ -1287,6 +1287,179 @@ components:
 
         Link:
         <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11556150%20and%20ver_nr=1>
+    cde.v1.namespace.StudyFundingId:
+      type: string
+      description: |-
+        **`caDSR CDE 14528051 v1.00`**
+
+        This metadata element is defined by the caDSR as "A sequence of characters
+        used to uniquely identify, name, or characterize the study funding
+        organization.".
+
+        Link:
+        <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=14528051%20and%20ver_nr=1>
+    cde.v1.namespace.StudyId:
+      type: string
+      description: |-
+        **`caDSR CDE 12960571 v1.00`**
+
+        This metadata element is defined by the caDSR as "A sequence of characters
+        used to identify, name, or characterize a pediatric study.".
+
+        Link:
+        <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=12960571%20and%20ver_nr=1>
+      enum:
+      - AALL0232
+      - AALL0331
+      - AALL03B1
+      - AALL0434
+      - AALL08B1
+      - AAML03P1
+      - AAML0531
+      - AAML1031
+      - AEIOPAML2002
+      - AEWS0031
+      - AEWS0331
+      - AEWS07P1
+      - AEWS1031
+      - AEWS1221
+      - AGCT0132
+      - AGCT01P1
+      - AGCT0521
+      - AHOD0031
+      - AHOD03P1
+      - AHOD0431
+      - AHOD0831
+      - AHOD1221
+      - AHOD1331
+      - AIEOPLAM92
+      - AMLBFM-Registry2012
+      - AMLBFM1998
+      - AMLBFM2004
+      - AMLBFM2012
+      - AMLBFMRegistry2017
+      - AOST0121
+      - AOST01P1
+      - AOST0221
+      - AOST0331/EURAMOS1
+      - AOST1321
+      - AOST1421
+      - CCG-782
+      - CCG-7942
+      - DBAML01
+      - EE99
+      - EICESS92
+      - GC1
+      - GC2
+      - GOG0078
+      - GOG0090
+      - GOG0116
+      - INT133
+      - JACLSAML99
+      - JPLSGAML05
+      - MRCAML12
+      - MRCAML15
+      - NOPHOAML2004
+      - NOPHOAML2012
+      - OS2006
+      - P9749
+      - P9754
+      - POG9049
+      - PPLLSGAML98
+      - REGOBONE
+      - Sarcome13/OS2016
+      - SCFEELAM02
+      - SJCRHAML02
+      - TCGM2004
+      - TE04
+      - TE05
+      - TE08
+      - TE09
+      - TE13
+      - TE20
+      - TE22
+      - TGM85
+      - TGM90
+      - TGM95
+      - TIP
+    cde.v1.namespace.StudyName:
+      type: string
+      description: |-
+        **`caDSR CDE 11459810 v1.00`**
+
+        This metadata element is defined by the caDSR as "The acronym or abbreviated
+        form of the title for a research data collection. Example – GLIOMA01".
+
+        Link:
+        <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11459810%20and%20ver_nr=1>
+    cde.v1.namespace.StudyShortTitle:
+      type: string
+      description: |-
+        **`caDSR CDE 11459812 v1.00`**
+
+        This metadata element is defined by the caDSR as "The narrative title used
+        as a textual label for a research data collection. Example – Comparative
+        Molecular Life History of Spontaneous Canine and Human Gliomas".
+
+        Link:
+        <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11459812%20and%20ver_nr=1>
+    cde.v1.organization.Institution:
+      type: string
+      description: |-
+        **`caDSR CDE 12662779 v1.00`**
+
+        This metadata element is defined by the caDSR as "A sequence of characters
+        used to identify, name, or characterize the laboratory, institute, or
+        consortium that provided the information.".
+
+        Link:
+        <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=12662779%20and%20ver_nr=1>
+      enum:
+      - AIEOP
+      - BFM-SG
+      - BOCG
+      - C3P
+      - CBTN
+      - CCLG
+      - CHLA
+      - COG
+      - COSS-GPOH
+      - CRCTU
+      - CWS
+      - DCOG
+      - DePICT
+      - DFCI
+      - EORTC
+      - EpSSG
+      - EuRBG
+      - EURO-EWING
+      - FSG
+      - GALOP
+      - GEIS
+      - GPOH
+      - IDIPGR
+      - ISG
+      - JACLS
+      - JCCG
+      - JINCS
+      - JNBSG
+      - JPLSG
+      - MRC
+      - NOPHO
+      - NRG-Oncology
+      - PNOC
+      - PPLLSG
+      - RBTR
+      - SFCE
+      - SIOP MMT
+      - SIOPE
+      - SIOPEN
+      - SJCRH
+      - SOPOBE
+      - SSG
+      - Treehouse
+      - UCL
+      - UK
     cde.v1.sample.DiseasePhase:
       type: string
       description: |-
@@ -1635,6 +1808,101 @@ components:
       properties:
         value:
           $ref: '#/components/schemas/cde.v1.file.Type'
+        ancestors:
+          type: array
+          items:
+            type: string
+          description: |-
+            The ancestors from which this field was derived.
+
+            Ancestors should be provided as period (`.`) delimited paths
+            from the `metadata` key in the subject response object.
+        comment:
+          type: string
+          description: A free-text comment field.
+    field.unowned.namespace.StudyFundingId:
+      type: object
+      required:
+      - value
+      properties:
+        value:
+          $ref: '#/components/schemas/cde.v1.namespace.StudyFundingId'
+        ancestors:
+          type: array
+          items:
+            type: string
+          description: |-
+            The ancestors from which this field was derived.
+
+            Ancestors should be provided as period (`.`) delimited paths
+            from the `metadata` key in the subject response object.
+        comment:
+          type: string
+          description: A free-text comment field.
+    field.unowned.namespace.StudyId:
+      type: object
+      required:
+      - value
+      properties:
+        value:
+          $ref: '#/components/schemas/cde.v1.namespace.StudyId'
+        ancestors:
+          type: array
+          items:
+            type: string
+          description: |-
+            The ancestors from which this field was derived.
+
+            Ancestors should be provided as period (`.`) delimited paths
+            from the `metadata` key in the subject response object.
+        comment:
+          type: string
+          description: A free-text comment field.
+    field.unowned.namespace.StudyName:
+      type: object
+      required:
+      - value
+      properties:
+        value:
+          $ref: '#/components/schemas/cde.v1.namespace.StudyName'
+        ancestors:
+          type: array
+          items:
+            type: string
+          description: |-
+            The ancestors from which this field was derived.
+
+            Ancestors should be provided as period (`.`) delimited paths
+            from the `metadata` key in the subject response object.
+        comment:
+          type: string
+          description: A free-text comment field.
+    field.unowned.namespace.StudyShortTitle:
+      type: object
+      required:
+      - value
+      properties:
+        value:
+          $ref: '#/components/schemas/cde.v1.namespace.StudyShortTitle'
+        ancestors:
+          type: array
+          items:
+            type: string
+          description: |-
+            The ancestors from which this field was derived.
+
+            Ancestors should be provided as period (`.`) delimited paths
+            from the `metadata` key in the subject response object.
+        comment:
+          type: string
+          description: A free-text comment field.
+    field.unowned.organization.Institution:
+      type: object
+      required:
+      - value
+      properties:
+        value:
+          $ref: '#/components/schemas/cde.v1.organization.Institution'
         ancestors:
           type: array
           items:
@@ -2131,7 +2399,7 @@ components:
           example: support@example.com
         metadata:
           allOf:
-          - $ref: '#/components/schemas/models.sample.Metadata'
+          - $ref: '#/components/schemas/models.namespace.Metadata'
           nullable: true
     models.Organization:
       type: object
@@ -2149,7 +2417,7 @@ components:
           $ref: '#/components/schemas/models.organization.Name'
         metadata:
           allOf:
-          - $ref: '#/components/schemas/models.subject.Metadata'
+          - $ref: '#/components/schemas/models.organization.Metadata'
           nullable: true
     models.Sample:
       type: object
@@ -2693,6 +2961,37 @@ components:
           $ref: '#/components/schemas/models.organization.Identifier'
         name:
           $ref: '#/components/schemas/models.namespace.identifier.Name'
+    models.namespace.Metadata:
+      allOf:
+      - $ref: '#/components/schemas/models.metadata.common.Metadata'
+      - type: object
+        required:
+        - study_short_title
+        - study_name
+        - study_funding_id
+        - study_id
+        properties:
+          study_short_title:
+            allOf:
+            - $ref: '#/components/schemas/field.unowned.namespace.StudyShortTitle'
+            nullable: true
+          study_name:
+            allOf:
+            - $ref: '#/components/schemas/field.unowned.namespace.StudyName'
+            nullable: true
+          study_funding_id:
+            type: array
+            items:
+              $ref: '#/components/schemas/field.unowned.namespace.StudyFundingId'
+            description: The study funding id.
+            nullable: true
+          study_id:
+            allOf:
+            - $ref: '#/components/schemas/field.unowned.namespace.StudyId'
+            nullable: true
+          unharmonized:
+            $ref: '#/components/schemas/fields.Unharmonized'
+      description: Metadata associated with a namespace.
     models.namespace.identifier.Name:
       type: string
       description: |-
@@ -2722,6 +3021,30 @@ components:
         **Note**: the regex for this field does not allow for any spaces because it is
         anticipated that the field will be displayable as a repository (e.g.,
         `example-organization/ExampleNamespace`).
+    models.organization.Metadata:
+      allOf:
+      - $ref: '#/components/schemas/models.metadata.common.Metadata'
+      - type: object
+        required:
+        - institution
+        properties:
+          institution:
+            type: array
+            items:
+              $ref: '#/components/schemas/field.unowned.organization.Institution'
+            description: |-
+              Institutions associated with an organization.
+
+              **NOTE:** in this design, an organization in not always a single
+              institution—it may also represent a consortium of institutions, for
+              instance. This is necessary, since a namespace can be tied to one and
+              only one organization in the API specification. As such, if the above is
+              not true, there is no way to make a namespace where data is contributed
+              from multiple institutions.
+            nullable: true
+          unharmonized:
+            $ref: '#/components/schemas/fields.Unharmonized'
+      description: Metadata associated with an organization.
     models.organization.Name:
       type: string
       description: |-


### PR DESCRIPTION
some fixes for #91 - there were some issues preventing the new metadata elements from appearing in the Swagger spec. See [my review](https://github.com/CBIIT/ccdi-federation-api/pull/91#pullrequestreview-2021420566) of #91 for a couple other items that this fix does _not_ include.

Fixes the Metadata element of Namespace to refer to its own metadata instead of models::sample::Metadata. 
Fixes the Metadata element of Organization to refer to its own metadata instead of models::subject::Metadata or models::file::Metadata.

Fixes a reference to "StudyFundingOrganization" in place of StudyFundingId.

Adds the following elements to swagger.yml:

cde.v1.namespace.StudyFundingId
cde.v1.namespace.StudyId
cde.v1.namespace.StudyName
cde.v1.namespace.StudyShortTitle
cde.v1.organization.Institution

field.unowned.namespace.StudyFundingId
field.unowned.namespace.StudyId
field.unowned.namespace.StudyName
field.unowned.namespace.StudyShortTitle
field.unowned.organization.Institution

models.namespace.Metadata
models.organization.Metadata

**PR Close Date:** [April 26]

_Describe the problem or feature in addition to a link to the issues._

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [n/a] You have updated the README or other documentation to account for these changes (when appropriate).
- [n/a] You have added a line describing the change in the `CHANGELOG.md` under `[Unreleased]`.
