### PR TITLE
revise: updates diagnosis to support multiple assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   values (effectively distinguishing `null` and strings) and (b) explicitly
   defined the behavior of each filter parameter
   ([#98](https://github.com/CBIIT/ccdi-federation-api/pull/98)).
+- Updates the sample's `diagnosis` field to support multiple values, as assigned
+  diagnoses are not incongruent across multiple ontologies 
+  ([#99](https://github.com/CBIIT/ccdi-federation-api/pull/99)).
 
 ### Fixed
 

--- a/packages/ccdi-models/src/sample/metadata.rs
+++ b/packages/ccdi-models/src/sample/metadata.rs
@@ -32,8 +32,8 @@ pub struct Metadata {
     age_at_diagnosis: Option<field::unowned::sample::AgeAtDiagnosis>,
 
     /// The diagnosis for the sample.
-    #[schema(value_type = field::unowned::sample::Diagnosis, nullable = true)]
-    diagnosis: Option<field::unowned::sample::Diagnosis>,
+    #[schema(value_type = Vec<field::unowned::sample::Diagnosis>, nullable = true)]
+    diagnosis: Option<Vec<field::unowned::sample::Diagnosis>>,
 
     /// The phase of the disease when this sample was acquired.
     #[schema(value_type = field::unowned::sample::DiseasePhase, nullable = true)]
@@ -132,12 +132,15 @@ impl Metadata {
     ///     models::sample::metadata::Diagnosis::from(String::from("Acute Lymphoblastic Leukemia"));
     ///
     /// let metadata = Builder::default()
-    ///     .diagnosis(Diagnosis::new(diagnosis.clone(), None, None, None))
+    ///     .push_diagnosis(Diagnosis::new(diagnosis.clone(), None, None, None))
     ///     .build();
     ///
-    /// assert_eq!(metadata.diagnosis().unwrap().value(), &diagnosis);
+    /// assert_eq!(
+    ///     metadata.diagnosis().unwrap().iter().next().unwrap().value(),
+    ///     &diagnosis
+    /// );
     /// ```
-    pub fn diagnosis(&self) -> Option<&field::unowned::sample::Diagnosis> {
+    pub fn diagnosis(&self) -> Option<&Vec<field::unowned::sample::Diagnosis>> {
         self.diagnosis.as_ref()
     }
 
@@ -557,12 +560,12 @@ impl Metadata {
                 None,
                 None,
             )),
-            diagnosis: Some(field::unowned::sample::Diagnosis::new(
+            diagnosis: Some(vec![field::unowned::sample::Diagnosis::new(
                 Diagnosis::from(String::from("Random Diagnosis")),
                 None,
                 None,
                 None,
-            )),
+            )]),
             disease_phase: rand::random(),
             library_strategy: rand::random(),
             preservation_method: rand::random(),

--- a/packages/ccdi-models/src/sample/metadata/builder.rs
+++ b/packages/ccdi-models/src/sample/metadata/builder.rs
@@ -11,8 +11,8 @@ pub struct Builder {
     /// The approximate age at diagnosis.
     age_at_diagnosis: Option<field::unowned::sample::AgeAtDiagnosis>,
 
-    /// The diagnosis for the sample.
-    diagnosis: Option<field::unowned::sample::Diagnosis>,
+    /// Diagnosis values for the sample.
+    diagnosis: Option<Vec<field::unowned::sample::Diagnosis>>,
 
     /// The phase of the disease when this sample was acquired.
     disease_phase: Option<field::unowned::sample::DiseasePhase>,
@@ -85,10 +85,20 @@ impl Builder {
     /// let diagnosis =
     ///     models::sample::metadata::Diagnosis::from(String::from("Acute Lymphoblastic Leukemia"));
     ///
-    /// let builder = Builder::default().diagnosis(Diagnosis::new(diagnosis.clone(), None, None, None));
+    /// let builder = Builder::default()
+    ///     .push_diagnosis(Diagnosis::new(diagnosis.clone(), None, None, None))
+    ///     .push_diagnosis(Diagnosis::new(diagnosis.clone(), None, None, None));
     /// ```
-    pub fn diagnosis(mut self, field: field::unowned::sample::Diagnosis) -> Self {
-        self.diagnosis = Some(field);
+    pub fn push_diagnosis(mut self, field: field::unowned::sample::Diagnosis) -> Self {
+        let diagnosis = match self.diagnosis {
+            Some(mut diagnosis) => {
+                diagnosis.push(field);
+                diagnosis
+            }
+            None => vec![field],
+        };
+
+        self.diagnosis = Some(diagnosis);
         self
     }
 

--- a/packages/ccdi-server/src/filter/sample.rs
+++ b/packages/ccdi-server/src/filter/sample.rs
@@ -201,7 +201,10 @@ impl FilterMetadataField<Sample, FilterSampleParams> for Vec<Sample> {
                         Value::String(query) => {
                             if let Some(metadata) = sample.metadata() {
                                 if let Some(diagnosis) = metadata.diagnosis() {
-                                    if diagnosis.to_string().contains(query) {
+                                    if diagnosis
+                                        .iter()
+                                        .any(|value| value.to_string().contains(query))
+                                    {
                                         // The user is requesting all samples
                                         // with a particular substring, and
                                         // this sample includes a metadata block

--- a/swagger.yml
+++ b/swagger.yml
@@ -3847,8 +3847,10 @@ components:
             - $ref: '#/components/schemas/field.unowned.sample.AgeAtDiagnosis'
             nullable: true
           diagnosis:
-            allOf:
-            - $ref: '#/components/schemas/field.unowned.sample.Diagnosis'
+            type: array
+            items:
+              $ref: '#/components/schemas/field.unowned.sample.Diagnosis'
+            description: The diagnosis for the sample.
             nullable: true
           disease_phase:
             allOf:


### PR DESCRIPTION
**PR Close Date:** April 30, 2024

It occurred to me that the concepts of harmonized diagnosis across the various ontologies are not incompatible in our current setup. As such, I've changed the sample's diagnosis metadata field to accept an array of values instead of a singular value to support multiple assignments.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional
  Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these
  changes (when appropriate).
- [x] You have added a line describing the change in the `CHANGELOG.md` under
  `[Unreleased]`.

<!--

If you are adding new metadata elements, please uncomment this section and
complete the checklist as well:

- [ ] I have added my field definition to the appropriate
  `get_field_descriptions()` method. For example, if you add a field to
  subjects, you should include it in the `get_field_descriptions()` method at
  `packages/ccdi_models/src/metadata/field/description/harmonized/subject.rs`.
- [ ] I have confirmed that my field shows up in the relevant
  `/metadata/fields/<entity>` endpoint. For example. if you add a field to
  subjects, it should show up in the fields listed in the output of the
  `/metadata/fields/subject` endpoint.
- [ ] I have confirmed that my field shows up in the relevant wiki generation
  command. For example. if you add a field to subjects, it should show up in the
  `cargo run --release wiki subject` output.

-->
