### PR TITLE
[EXPERIMENTAL] revise: changes filters to use `POST` requests

### DIFF
--- a/packages/ccdi-openapi/src/api.rs
+++ b/packages/ccdi-openapi/src/api.rs
@@ -77,18 +77,21 @@ use utoipa::openapi;
     paths(
         // Subject routes.
         server::routes::subject::subject_index,
+        server::routes::subject::subject_filter,
         server::routes::subject::subject_show,
         server::routes::subject::subjects_by_count,
         server::routes::subject::subject_summary,
 
         // Sample routes.
         server::routes::sample::sample_index,
+        server::routes::sample::sample_filter,
         server::routes::sample::sample_show,
         server::routes::sample::samples_by_count,
         server::routes::sample::sample_summary,
 
         // File routes.
         server::routes::file::file_index,
+        server::routes::file::file_filter,
         server::routes::file::file_show,
         server::routes::file::files_by_count,
         server::routes::file::file_summary,
@@ -314,7 +317,12 @@ use utoipa::openapi;
 
         // Error responses.
         responses::error::Kind,
-        responses::Errors
+        responses::Errors,
+
+        // Filters.
+        server::params::filter::Subject,
+        server::params::filter::Sample,
+        server::params::filter::File,
     )),
     modifiers(
         &RemoveLicense,

--- a/packages/ccdi-server/src/filter.rs
+++ b/packages/ccdi-server/src/filter.rs
@@ -115,13 +115,14 @@ where
 /// let mut results = filter::<Subject, SubjectFilterParams>(
 ///     subjects.clone(),
 ///     SubjectFilterParams {
-///         sex: Some(String::from("\"F\"")),
+///         sex: Some(Some(String::from("F"))),
 ///         race: None,
 ///         ethnicity: None,
 ///         identifier: None,
 ///         vital_status: None,
 ///         age_at_vital_status: None,
 ///         deposition: None,
+///         unharmonized: None,
 ///     },
 /// )?;
 ///
@@ -139,13 +140,14 @@ where
 /// let mut results = filter::<Subject, SubjectFilterParams>(
 ///     subjects.clone(),
 ///     SubjectFilterParams {
-///         sex: Some(String::from("\"F\"")),
-///         race: Some(String::from("\"Asian\"")),
+///         sex: Some(Some(String::from("F"))),
+///         race: Some(Some(String::from("Asian"))),
 ///         ethnicity: None,
 ///         identifier: None,
 ///         vital_status: None,
 ///         age_at_vital_status: None,
 ///         deposition: None,
+///         unharmonized: None,
 ///     },
 /// )?;
 ///
@@ -159,13 +161,14 @@ where
 /// let mut results = filter::<Subject, SubjectFilterParams>(
 ///     subjects.clone(),
 ///     SubjectFilterParams {
-///         sex: Some(String::from("\"f\"")),
+///         sex: Some(Some(String::from("f"))),
 ///         race: None,
 ///         ethnicity: None,
 ///         identifier: None,
 ///         vital_status: None,
 ///         age_at_vital_status: None,
 ///         deposition: None,
+///         unharmonized: None,
 ///     },
 /// )?;
 ///

--- a/packages/ccdi-server/src/filter/file.rs
+++ b/packages/ccdi-server/src/filter/file.rs
@@ -8,7 +8,6 @@ use serde_json::Value;
 
 use crate::filter::FilterMetadataField;
 use crate::params::filter::File as FilterFileParams;
-use crate::responses::error::Kind;
 use crate::responses::Errors;
 
 impl FilterMetadataField<File, FilterFileParams> for Vec<File> {
@@ -18,81 +17,33 @@ impl FilterMetadataField<File, FilterFileParams> for Vec<File> {
         params: &FilterFileParams,
     ) -> Result<Vec<File>, Errors> {
         let parameter = match field.as_str() {
-            "type" => &params.r#type,
-            "size" => &params.size,
-            "checksum" => &params.checksum,
-            "description" => &params.description,
-            "deposition" => &params.deposition,
-            _ => unreachable!("unhandled file metadata field: {field}"),
-        };
-
-        let parameter = match parameter {
-            Some(parameter) => match parameter.parse::<Value>() {
-                Ok(value) => value,
-                Err(_) => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![field.to_string()]),
-                        String::from("Parameter was not a valid JSON value."),
-                    )]));
-                }
+            "type" => match &params.r#type {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            None => {
-                // If the parameter has no value, just return the original list of
-                // files, as the user does not want to filter based on that.
-                return Ok(self);
-            }
-        };
-
-        let parameter = match field.as_str() {
-            "type" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("type")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
-                }
+            "size" => match &params.size {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "size" => match parameter {
-                Value::Null => Value::Null,
-                Value::Number(value) => Value::Number(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("size")]),
-                        String::from("Parameter was not a number or null."),
-                    )]));
-                }
+            "checksum" => match &params.checksum {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "checksum" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("checksum")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
-                }
+            "description" => match &params.description {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "description" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("description")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
-                }
+            "deposition" => match &params.deposition {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "deposition" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("deposition")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
+            "unharmonized" => match &params.unharmonized {
+                Some(_) => {
+                    // NOTE: this server does not support filtering by unharmonized data
+                    // because it does not produce any yet.
+                    todo!("this server does not yet support filtering unharmonized data")
                 }
+                None => return Ok(self),
             },
             _ => unreachable!("unhandled file metadata field: {field}"),
         };

--- a/packages/ccdi-server/src/filter/sample.rs
+++ b/packages/ccdi-server/src/filter/sample.rs
@@ -10,7 +10,6 @@ use serde_json::Value;
 
 use crate::filter::FilterMetadataField;
 use crate::params::filter::Sample as FilterSampleParams;
-use crate::responses::error::Kind;
 use crate::responses::Errors;
 
 impl FilterMetadataField<Sample, FilterSampleParams> for Vec<Sample> {
@@ -20,148 +19,57 @@ impl FilterMetadataField<Sample, FilterSampleParams> for Vec<Sample> {
         params: &FilterSampleParams,
     ) -> Result<Vec<Sample>, Errors> {
         let parameter = match field.as_str() {
-            "age_at_diagnosis" => &params.age_at_diagnosis,
-            "diagnosis" => &params.diagnosis,
-            "disease_phase" => &params.disease_phase,
-            "tissue_type" => &params.tissue_type,
-            "tumor_classification" => &params.tumor_classification,
-            "tumor_tissue_morphology" => &params.tumor_tissue_morphology,
-            "age_at_collection" => &params.age_at_collection,
-            "library_strategy" => &params.library_strategy,
-            "preservation_method" => &params.preservation_method,
-            "identifier" => &params.identifier,
-            "deposition" => &params.deposition,
-            _ => unreachable!("unhandled sample metadata field: {field}"),
-        };
-
-        let parameter = match parameter {
-            Some(parameter) => match parameter.parse::<Value>() {
-                Ok(value) => value,
-                Err(_) => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![field.to_string()]),
-                        String::from("Parameter was not a valid JSON value."),
-                    )]));
-                }
+            "age_at_diagnosis" => match &params.age_at_diagnosis {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            None => {
-                // If the parameter has no value, just return the original list
-                // of samples, as the user does not want to filter based on
-                // that.
-                return Ok(self);
-            }
-        };
-
-        let parameter = match field.as_str() {
-            "age_at_diagnosis" => match parameter {
-                Value::Null => Value::Null,
-                Value::Number(value) => Value::Number(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("age_at_diagnosis")]),
-                        String::from("Parameter was not a number or null."),
-                    )]));
-                }
+            "diagnosis" => match &params.diagnosis {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "diagnosis" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("diagnosis")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
-                }
+            "disease_phase" => match &params.disease_phase {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "disease_phase" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("disease_phase")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
-                }
+            "tissue_type" => match &params.tissue_type {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "tissue_type" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("tissue_type")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
-                }
+            "tumor_classification" => match &params.tumor_classification {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "tumor_classification" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("tumor_classification")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
-                }
+            "tumor_tissue_morphology" => match &params.tumor_tissue_morphology {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "tumor_tissue_morphology" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("tumor_tissue_morphology")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
-                }
+            "age_at_collection" => match &params.age_at_collection {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "age_at_collection" => match parameter {
-                Value::Null => Value::Null,
-                Value::Number(value) => Value::Number(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("age_at_collection")]),
-                        String::from("Parameter was not a number or null."),
-                    )]));
-                }
+            "library_strategy" => match &params.library_strategy {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "library_strategy" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("library_strategy")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
-                }
+            "preservation_method" => match &params.preservation_method {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "preservation_method" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("preservation_method")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
-                }
+            "identifier" => match &params.identifier {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "identifier" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("identifier")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
-                }
+            "deposition" => match &params.deposition {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "deposition" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("deposition")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
+            "unharmonized" => match &params.unharmonized {
+                Some(_) => {
+                    // NOTE: this server does not support filtering by unharmonized data
+                    // because it does not produce any yet.
+                    todo!("this server does not yet support filtering unharmonized data")
                 }
+                None => return Ok(self),
             },
             _ => unreachable!("unhandled sample metadata field: {field}"),
         };

--- a/packages/ccdi-server/src/filter/subject.rs
+++ b/packages/ccdi-server/src/filter/subject.rs
@@ -10,7 +10,6 @@ use serde_json::Value;
 
 use crate::filter::FilterMetadataField;
 use crate::params::filter::Subject as FilterSubjectParams;
-use crate::responses::error::Kind;
 use crate::responses::Errors;
 
 impl FilterMetadataField<Subject, FilterSubjectParams> for Vec<Subject> {
@@ -20,104 +19,41 @@ impl FilterMetadataField<Subject, FilterSubjectParams> for Vec<Subject> {
         params: &FilterSubjectParams,
     ) -> Result<Vec<Subject>, Errors> {
         let parameter = match field.as_str() {
-            "sex" => &params.sex,
-            "race" => &params.race,
-            "ethnicity" => &params.ethnicity,
-            "identifier" => &params.identifier,
-            "vital_status" => &params.vital_status,
-            "age_at_vital_status" => &params.age_at_vital_status,
-            "deposition" => &params.deposition,
-            _ => unreachable!("unhandled subject metadata field: {field}"),
-        };
-
-        let parameter = match parameter {
-            Some(parameter) => match parameter.parse::<Value>() {
-                Ok(value) => value,
-                Err(_) => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![field.to_string()]),
-                        String::from("Parameter was not a valid JSON value."),
-                    )]));
-                }
+            "sex" => match &params.sex {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            None => {
-                // If the parameter has no value, just return the original list
-                // of subjects, as the user does not want to filter based on
-                // that.
-                return Ok(self);
-            }
-        };
-
-        let parameter = match field.as_str() {
-            "sex" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("sex")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
-                }
+            "race" => match &params.race {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "race" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("race")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
-                }
+            "ethnicity" => match &params.ethnicity {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "ethnicity" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("ethnicity")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
-                }
+            "identifier" => match &params.identifier {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "identifier" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("identifier")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
-                }
+            "vital_status" => match &params.vital_status {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "vital_status" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("vital_status")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
-                }
+            "age_at_vital_status" => match &params.age_at_vital_status {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "age_at_vital_status" => match parameter {
-                Value::Null => Value::Null,
-                Value::Number(value) => Value::Number(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("age_at_vital_status")]),
-                        String::from("Parameter was not a number or null."),
-                    )]));
-                }
+            "deposition" => match &params.deposition {
+                Some(value) => serde_json::to_value(value.to_owned()).unwrap(),
+                None => return Ok(self),
             },
-            "deposition" => match parameter {
-                Value::Null => Value::Null,
-                Value::String(value) => Value::String(value.to_owned()),
-                _ => {
-                    return Err(Errors::new(vec![Kind::invalid_parameters(
-                        Some(vec![String::from("deposition")]),
-                        String::from("Parameter was not a string or null."),
-                    )]));
+            "unharmonized" => match &params.unharmonized {
+                Some(_) => {
+                    // NOTE: this server does not support filtering by unharmonized data
+                    // because it does not produce any yet.
+                    todo!("this server does not yet support filtering unharmonized data")
                 }
+                None => return Ok(self),
             },
             _ => unreachable!("unhandled subject metadata field: {field}"),
         };

--- a/packages/ccdi-server/src/params/filter.rs
+++ b/packages/ccdi-server/src/params/filter.rs
@@ -1,26 +1,28 @@
 //! Parameters related to filtering.
 
+use std::collections::HashMap;
+
 use introspect::Introspect;
 use serde::Deserialize;
 use serde::Serialize;
-use utoipa::IntoParams;
+use serde_json::Value;
+use utoipa::ToSchema;
 
 /// Parameters for filtering subjects.
 ///
-/// Parameters for filtering subjects are declared as valid JSON values.
-/// Importantly, values must appear _exactly_ as they would in a JSON object
-/// (so, for example, strings must be included within quotes). Failure to
-/// provide filter parameters as a parsable JSON value will result in an error
-/// being thrown. When a parameter is provided, the endpoint will filter the
-/// results according to the rules described for that parameter.
+/// Parameters for filtering subjects are declared as JSON objects. For each key
+/// provided that matches a valid metadata field in a subject, the endpoint will
+/// filter the results according to the rules described for each field and
+/// intersect the results.
 ///
-/// When strings are provided, matching is case-sensitive unless otherwise
-/// stated. None of the parameters are required to be included.
-#[derive(Debug, Default, Deserialize, IntoParams, Introspect, Serialize)]
-#[into_params(parameter_in = Query)]
+/// Note that, when strings are provided, matching is case-sensitive unless
+/// otherwise stated. At least one valid parameter for subjects must be included
+/// in the `/subject/filter` request.
+#[derive(Debug, Default, Deserialize, Introspect, Serialize, ToSchema)]
+#[schema(as = server::params::filter::Subject)]
 pub struct Subject {
     /// Matches any subject where the `sex` field exactly matches the specified
-    /// JSON value.
+    /// value.
     ///
     /// This parameter can either be a JSON string (surrounded by quotes) or
     /// `null`.
@@ -31,17 +33,18 @@ pub struct Subject {
     /// - If a string is provided, all entries where `sex` exactly matches the
     ///   provided string are included in the results.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter `?sex="F"` to select all
+    /// For example, you might provide the filter `{ "sex": "F" }` to select all
     /// subjects with a `sex` of `F`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub sex: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub sex: Option<Option<String>>,
 
     /// Matches subjects to their `race` value(s) according to the rules laid
     /// out below.
@@ -55,21 +58,22 @@ pub struct Subject {
     ///   matches the provided string are included in the results. Note that
     ///   this is effectively a logical OR (`||`) across any of the race values.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter `?race="American Indian or
-    /// Alaska Native"` to select any subjects where any race matches this
+    /// For example, you might provide the filter `{ "race": "American Indian or
+    /// Alaska Native" }` to select any subjects where any race matches this
     /// string.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub race: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub race: Option<Option<String>>,
 
     /// Matches any subject where the `ethnicity` field exactly matches the
-    /// specified JSON value.
+    /// specified value.
     ///
     /// This parameter can either be a JSON string (surrounded by quotes) or
     /// `null`.
@@ -80,18 +84,19 @@ pub struct Subject {
     /// - If a string is provided, all entries where `ethnicity` exactly matches
     ///   the provided string are included in the results.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter `?ethnicity="Hispanic or
-    /// Latino"` to select all subjects with a `ethnicity` of `Hispanic or
+    /// For example, you might provide the filter `{ "ethnicity": "Hispanic or
+    /// Latino" }` to select all subjects with a `ethnicity` of `Hispanic or
     /// Latino`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub ethnicity: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub ethnicity: Option<Option<String>>,
 
     /// Matches subjects to their `identifiers` value(s) according to the rules
     /// laid out below.
@@ -106,21 +111,22 @@ pub struct Subject {
     ///   results. Note that this is effectively a logical OR (`||`) across any
     ///   of the identifier name values.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter
-    /// `?identifier="Subject-OZNL7P47"` to select any subjects where any
-    /// identifiers matches this string.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub identifier: Option<String>,
+    /// For example, you might provide the filter `{ "identifier":
+    /// "Subject-OZNL7P47" }` to select any subjects where any identifiers
+    /// matches this string.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub identifier: Option<Option<String>>,
 
     /// Matches any subject where the `vital_status` field exactly matches the
-    /// specified JSON value.
+    /// specified value.
     ///
     /// This parameter can either be a JSON string (surrounded by quotes) or
     /// `null`.
@@ -131,20 +137,21 @@ pub struct Subject {
     /// - If a string is provided, all entries where `vital_status` exactly
     ///   matches the provided string are included in the results.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter `?vital_status="Alive"` to
-    /// select all subjects with a `vital_status` of `Alive`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub vital_status: Option<String>,
+    /// For example, you might provide the filter `{ "vital_status": "Alive" }`
+    /// to select all subjects with a `vital_status` of `Alive`.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub vital_status: Option<Option<String>>,
 
     /// Matches any subject where the `age_at_vital_status` field exactly
-    /// matches the specified JSON value.
+    /// matches the specified value.
     ///
     /// This parameter can either be a JSON number (surrounded by quotes) or
     /// `null`.
@@ -155,17 +162,19 @@ pub struct Subject {
     /// - If a number is provided, all entries where `age_at_vital_status`
     ///   exactly matches the provided number are included in the results.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter `?age_at_vital_status=365.25`
-    /// to select all subjects with a `age_at_vital_status` of `365.25`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub age_at_vital_status: Option<String>,
+    /// For example, you might provide the filter `{ "age_at_vital_status":
+    /// 365.25 }` to select all subjects with a `age_at_vital_status` of
+    /// `365.25`.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub age_at_vital_status: Option<Option<f64>>,
 
     /// Matches subjects to their `depositions` value(s) according to the rules
     /// laid out below.
@@ -180,36 +189,87 @@ pub struct Subject {
     ///   that this is effectively a logical OR (`||`) across any of the
     ///   deposition values.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter
-    /// `?deposition="phs000000.v1.p1"` to select any subjects where any
-    /// deposition value matches this string.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub deposition: Option<String>,
+    /// For example, you might provide the filter `{ "deposition":
+    /// "phs000000.v1.p1" }` to select any subjects where any deposition value
+    /// matches this string.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub deposition: Option<Option<String>>,
+
+    /// All unharmonized fields should be filterable as well:
+    ///
+    /// * Filtering on a singular field should include the `Subject` in the
+    /// results if the query exactly matches the value of that field for the
+    /// `Subject` (case-sensitive).
+    /// * Filtering on field with multiple values should include the `Subject`
+    /// in the results if the query exactly matches any of the values of the
+    /// field for that `Subject` (case-sensitive).
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    pub unharmonized: Option<Option<HashMap<String, Value>>>,
+}
+
+impl Subject {
+    /// Checks to see if the parameters are empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_server as server;
+    /// use server::params::filter::Subject;
+    ///
+    /// // This is intentionally not default to ensure all fields are
+    /// // accounted for explicitly.
+    /// let params = Subject {
+    ///     sex: None,
+    ///     race: None,
+    ///     ethnicity: None,
+    ///     identifier: None,
+    ///     vital_status: None,
+    ///     age_at_vital_status: None,
+    ///     deposition: None,
+    ///     unharmonized: None,
+    /// };
+    ///
+    /// assert!(params.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.sex.is_none()
+            && self.race.is_none()
+            && self.ethnicity.is_none()
+            && self.identifier.is_none()
+            && self.vital_status.is_none()
+            && self.age_at_vital_status.is_none()
+            && self.deposition.is_none()
+            && self.unharmonized.is_none()
+    }
 }
 
 /// Parameters for filtering samples.
 ///
-/// Parameters for filtering samples are declared as valid JSON values.
-/// Importantly, values must appear _exactly_ as they would in a JSON object
-/// (so, for example, strings must be included within quotes). Failure to
-/// provide filter parameters as a parsable JSON value will result in an error
-/// being thrown. When a parameter is provided, the endpoint will filter the
-/// results according to the rules described for that parameter.
+/// Parameters for filtering samples are declared as JSON objects. For each key
+/// provided that matches a valid metadata field in a sample, the endpoint will
+/// filter the results according to the rules described for each field and
+/// intersect the results.
 ///
-/// When strings are provided, matching is case-sensitive unless otherwise
-/// stated. None of the parameters are required to be included.
-#[derive(Debug, Default, Deserialize, IntoParams, Introspect, Serialize)]
-#[into_params(parameter_in = Query)]
+/// Note that, when strings are provided, matching is case-sensitive unless
+/// otherwise stated. At least one valid parameter for samples must be included
+/// in the `/sample/filter` request.
+#[derive(Debug, Default, Deserialize, Introspect, Serialize, ToSchema)]
+#[schema(as = server::params::filter::Sample)]
 pub struct Sample {
     /// Matches any sample where the `age_at_diagnosis` field exactly matches
-    /// the specified JSON value.
+    /// the specified value.
     ///
     /// This parameter can either be a JSON number or `null`.
     ///
@@ -219,17 +279,18 @@ pub struct Sample {
     /// - If a number is provided, all entries where `age_at_diagnosis` exactly
     ///   matches the provided number are included in the results.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter `?age_at_diagnosis=365.25` to
-    /// select all samples with a `age_at_diagnosis` of `365.25`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub age_at_diagnosis: Option<String>,
+    /// For example, you might provide the filter `{ "age_at_diagnosis": 365.25
+    /// }` to select all samples with a `age_at_diagnosis` of `365.25`.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub age_at_diagnosis: Option<Option<f64>>,
 
     /// Matches samples to their `diagnosis` value(s) according to the rules
     /// laid out below.
@@ -244,24 +305,25 @@ pub struct Sample {
     ///   this is effectively a logical OR (`||`) across any of the diagnosis
     ///   values containing the substring.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter `?diagnosis="sarcoma"` to
-    /// select any samples where any diagnosis value contains the string
+    /// For example, you might provide the filter `{ "diagnosis": "sarcoma" }`
+    /// to select any samples where any diagnosis value contains the string
     /// `sarcoma`.
     ///
     /// **Note:** this filter parameter contains non-standard filtering
     /// criteria—implementors should carefully read the description above.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub diagnosis: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub diagnosis: Option<Option<String>>,
 
     /// Matches any sample where the `disease_phase` field exactly matches the
-    /// specified JSON value.
+    /// specified value.
     ///
     /// This parameter can either be a JSON string (surrounded by quotes) or
     /// `null`.
@@ -272,21 +334,22 @@ pub struct Sample {
     /// - If a string is provided, all entries where `disease_phase` exactly
     ///   matches the provided string are included in the results.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter `?disease_phase="Initial
-    /// Diagnosis"` to select all samples with a `disease_phase` of `Initial
+    /// For example, you might provide the filter `{ "disease_phase": "Initial
+    /// Diagnosis" }` to select all samples with a `disease_phase` of `Initial
     /// Diagnosis`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub disease_phase: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub disease_phase: Option<Option<String>>,
 
     /// Matches any sample where the `tissue_type` field exactly matches the
-    /// specified JSON value.
+    /// specified value.
     ///
     /// This parameter can either be a JSON string (surrounded by quotes) or
     /// `null`.
@@ -297,20 +360,22 @@ pub struct Sample {
     /// - If a string is provided, all entries where `tissue_type` exactly
     ///   matches the provided string are included in the results.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter `?tissue_type="Unspecified"`
-    /// to select all samples with a `tissue_type` of `Unspecified`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub tissue_type: Option<String>,
+    /// For example, you might provide the filter `{ "tissue_type":
+    /// "Unspecified" }` to select all samples with a `tissue_type` of
+    /// `Unspecified`.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub tissue_type: Option<Option<String>>,
 
     /// Matches any sample where the `tumor_classification` field exactly
-    /// matches the specified JSON value.
+    /// matches the specified value.
     ///
     /// This parameter can either be a JSON string (surrounded by quotes) or
     /// `null`.
@@ -322,18 +387,19 @@ pub struct Sample {
     /// - If a string is provided, all entries where `tumor_classification`
     ///   exactly matches the provided string are included in the results.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter
-    /// `?tumor_classification="Regional"` to select all samples with a
-    /// `tumor_classification` of `Regional`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub tumor_classification: Option<String>,
+    /// For example, you might provide the filter `{ "tumor_classification":
+    /// "Regional" }` to select all samples with a `tumor_classification` of
+    /// `Regional`.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub tumor_classification: Option<Option<String>>,
 
     /// Matches samples to their `tumor_tissue_morphology` value(s) according to
     /// the rules laid out below.
@@ -349,21 +415,22 @@ pub struct Sample {
     ///   are included in the results. Note that this is effectively a logical
     ///   OR (`||`) across any of the tumor tissue morphology values.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter
-    /// `?tumor_tissue_morphology="8000/0"` to select any samples where any
-    /// tumor tissue morphology matches this string.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub tumor_tissue_morphology: Option<String>,
+    /// For example, you might provide the filter `{ "tumor_tissue_morphology":
+    /// "8000/0" }` to select any samples where any tumor tissue morphology
+    /// matches this string.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub tumor_tissue_morphology: Option<Option<String>>,
 
     /// Matches any sample where the `age_at_collection` field exactly matches
-    /// the specified JSON value.
+    /// the specified value.
     ///
     /// This parameter can either be a JSON number or `null`.
     ///
@@ -373,20 +440,21 @@ pub struct Sample {
     /// - If a number is provided, all entries where `age_at_collection` exactly
     ///   matches the provided number are included in the results.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter `?age_at_collection=365.25` to
-    /// select all samples with a `age_at_collection` of `365.25`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub age_at_collection: Option<String>,
+    /// For example, you might provide the filter `{ "age_at_collection": 365.25
+    /// }` to select all samples with a `age_at_collection` of `365.25`.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub age_at_collection: Option<Option<f64>>,
 
     /// Matches any sample where the `library_strategy` field exactly matches
-    /// the specified JSON value.
+    /// the specified value.
     ///
     /// This parameter can either be a JSON string (surrounded by quotes) or
     /// `null`.
@@ -397,20 +465,22 @@ pub struct Sample {
     /// - If a string is provided, all entries where `library_strategy` exactly
     ///   matches the provided string are included in the results.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter `?library_strategy="DNA-Seq"`
-    /// to select all samples with a `library_strategy` of `DNA-Seq`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub library_strategy: Option<String>,
+    /// For example, you might provide the filter `{ "library_strategy":
+    /// "DNA-Seq" }` to select all samples with a `library_strategy` of
+    /// `DNA-Seq`.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub library_strategy: Option<Option<String>>,
 
     /// Matches any sample where the `preservation_method` field exactly matches
-    /// the specified JSON value.
+    /// the specified value.
     ///
     /// This parameter can either be a JSON string (surrounded by quotes) or
     /// `null`.
@@ -421,18 +491,19 @@ pub struct Sample {
     /// - If a string is provided, all entries where `preservation_method`
     ///   exactly matches the provided string are included in the results.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter
-    /// `?preservation_method="Cryopreserved"` to select all samples with a
-    /// `preservation_method` of `Cryopreserved`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub preservation_method: Option<String>,
+    /// For example, you might provide the filter `{ "preservation_method":
+    /// "Cryopreserved" }` to select all samples with a `preservation_method` of
+    /// `Cryopreserved`.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub preservation_method: Option<Option<String>>,
 
     /// Matches samples to their `identifiers` value(s) according to the rules
     /// laid out below.
@@ -447,18 +518,19 @@ pub struct Sample {
     ///   results. Note that this is effectively a logical OR (`||`) across any
     ///   of the identifier name values.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter
-    /// `?identifier="Sample-F62VO0JV"` to select any samples where any
-    /// identifiers matches this string.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub identifier: Option<String>,
+    /// For example, you might provide the filter `{ "identifier":
+    /// "Sample-F62VO0JV" }` to select any samples where any identifiers matches
+    /// this string.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub identifier: Option<Option<String>>,
 
     /// Matches samples to their `depositions` value(s) according to the rules
     /// laid out below.
@@ -473,36 +545,95 @@ pub struct Sample {
     ///   that this is effectively a logical OR (`||`) across any of the
     ///   deposition values.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter
-    /// `?deposition="phs000000.v1.p1"` to select any samples where any
-    /// deposition value matches this string.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub deposition: Option<String>,
+    /// For example, you might provide the filter `{ "deposition":
+    /// "phs000000.v1.p1" }` to select any samples where any deposition value
+    /// matches this string.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub deposition: Option<Option<String>>,
+
+    /// All unharmonized fields should be filterable as well:
+    ///
+    /// * Filtering on a singular field should include the `Sample` in the
+    /// results if the query exactly matches the value of that field for the
+    /// `Sample` (case-sensitive).
+    /// * Filtering on field with multiple values should include the `Sample` in
+    /// the results if the query exactly matches any of the values of the field
+    /// for that `Sample` (case-sensitive).
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    pub unharmonized: Option<Option<HashMap<String, Value>>>,
+}
+
+impl Sample {
+    /// Checks to see if the parameters are empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_server as server;
+    /// use server::params::filter::Sample;
+    ///
+    /// // This is intentionally not default to ensure all fields are
+    /// // accounted for explicitly.
+    /// let params = Sample {
+    ///     age_at_diagnosis: None,
+    ///     diagnosis: None,
+    ///     disease_phase: None,
+    ///     tissue_type: None,
+    ///     tumor_classification: None,
+    ///     tumor_tissue_morphology: None,
+    ///     age_at_collection: None,
+    ///     library_strategy: None,
+    ///     preservation_method: None,
+    ///     identifier: None,
+    ///     deposition: None,
+    ///     unharmonized: None,
+    /// };
+    ///
+    /// assert!(params.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.age_at_diagnosis.is_none()
+            && self.diagnosis.is_none()
+            && self.disease_phase.is_none()
+            && self.tissue_type.is_none()
+            && self.tumor_classification.is_none()
+            && self.tumor_tissue_morphology.is_none()
+            && self.age_at_collection.is_none()
+            && self.library_strategy.is_none()
+            && self.preservation_method.is_none()
+            && self.identifier.is_none()
+            && self.deposition.is_none()
+            && self.unharmonized.is_none()
+    }
 }
 
 /// Parameters for filtering files.
 ///
-/// Parameters for filtering files are declared as valid JSON values.
-/// Importantly, values must appear _exactly_ as they would in a JSON object
-/// (so, for example, strings must be included within quotes). Failure to
-/// provide filter parameters as a parsable JSON value will result in an error
-/// being thrown. When a parameter is provided, the endpoint will filter the
-/// results according to the rules described for that parameter.
+/// Parameters for filtering files are declared as JSON objects. For each key
+/// provided that matches a valid metadata field in a file, the endpoint will
+/// filter the results according to the rules described for each field and
+/// intersect the results.
 ///
-/// When strings are provided, matching is case-sensitive unless otherwise
-/// stated. None of the parameters are required to be included.
-#[derive(Debug, Default, Deserialize, IntoParams, Introspect, Serialize)]
-#[into_params(parameter_in = Query)]
+/// Note that, when strings are provided, matching is case-sensitive unless
+/// otherwise stated. At least one valid parameter for files must be included in
+/// the `/file/filter` request.
+#[derive(Debug, Default, Deserialize, Introspect, Serialize, ToSchema)]
+#[schema(as = server::params::filter::File)]
 pub struct File {
     /// Matches any file where the `type` field exactly matches the specified
-    /// JSON value.
+    /// value.
     ///
     /// This parameter can either be a JSON string (surrounded by quotes) or
     /// `null`.
@@ -513,20 +644,21 @@ pub struct File {
     /// - If a string is provided, all entries where `type` exactly matches the
     ///   provided string are included in the results.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter `?type="TXT"` to select all
-    /// files with a type of `TXT`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub r#type: Option<String>,
+    /// For example, you might provide the filter `{ "type": "TXT" }` to select
+    /// all files with a type of `TXT`.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub r#type: Option<Option<String>>,
 
     /// Matches any file where the `size` field exactly matches the specified
-    /// JSON value.
+    /// value.
     ///
     /// This parameter can either be a JSON number or `null`.
     ///
@@ -536,17 +668,18 @@ pub struct File {
     /// - If a number is provided, all entries where `size` exactly matches the
     ///   provided number are included in the results.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter `?size=12345` to select all
-    /// files with a size of `12345`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub size: Option<String>,
+    /// For example, you might provide the filter `{ "size": 12345 }` to select
+    /// all files with a size of `12345`.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub size: Option<Option<usize>>,
 
     /// Matches files to their `checksums` value(s) according to the rules laid
     /// out below.
@@ -561,18 +694,19 @@ pub struct File {
     ///   that this is effectively a logical OR (`||`) across any of the
     ///   checksum values.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter
-    /// `?checksum="A9781F66C9C5C9DA8837132FFEB08CA"` to select any files where
-    /// any checksum matches this string.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub checksum: Option<String>,
+    /// For example, you might provide the filter `{ "checksum":
+    /// "A9781F66C9C5C9DA8837132FFEB08CA" }` to select any files where any
+    /// checksum matches this string.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub checksum: Option<Option<String>>,
 
     /// Matches files to their `description` value according to the rules laid
     /// out below.
@@ -586,20 +720,22 @@ pub struct File {
     /// - If a string is provided, all entries where the `description` contains
     ///   the string provided (case-sensitive) are included in the results.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter `?description="hello"` to
-    /// select all files where the description includes the substring `hello`.
+    /// For example, you might provide the filter `{ "description": "hello" }`
+    /// to select all files where the description includes the substring
+    /// `hello`.
     ///
     /// **Note:** this filter parameter contains non-standard filtering
     /// criteria—implementors should carefully read the description above.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub description: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub description: Option<Option<String>>,
 
     /// Matches files to their `depositions` value(s) according to the rules
     /// laid out below.
@@ -614,16 +750,64 @@ pub struct File {
     ///   that this is effectively a logical OR (`||`) across any of the
     ///   deposition values.
     ///
-    /// If a query parameter value is provided that is not able to be parsed as
-    /// a JSON value, an error should be returned indicating this. Further, if a
-    /// JSON value is able to be parsed, but the value is not one of the
-    /// acceptable value types above, an error should be returned indicating
-    /// this.
+    /// If the value is not one of the acceptable value types above, an error
+    /// should be returned indicating this.
     ///
-    /// For example, you might provide the filter
-    /// `?deposition="phs000000.v1.p1"` to select any files where any deposition
-    /// value matches this string.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[param(required = false)]
-    pub deposition: Option<String>,
+    /// For example, you might provide the filter `{ "deposition":
+    /// "phs000000.v1.p1" }` to select any files where any deposition value
+    /// matches this string.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    #[schema(required = false)]
+    pub deposition: Option<Option<String>>,
+
+    /// All unharmonized fields should be filterable as well:
+    ///
+    /// * Filtering on a singular field should include the `File` in the results
+    /// if the query exactly matches the value of that field for the `File`
+    /// (case-sensitive).
+    /// * Filtering on field with multiple values should include the `File` in
+    /// the results if the query exactly matches any of the values of the field
+    /// for that `File` (case-sensitive).
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "::serde_with::rust::double_option"
+    )]
+    pub unharmonized: Option<Option<HashMap<String, Value>>>,
+}
+
+impl File {
+    /// Checks to see if the parameters are empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_server as server;
+    /// use server::params::filter::File;
+    ///
+    /// // This is intentionally not default to ensure all fields are
+    /// // accounted for explicitly.
+    /// let params = File {
+    ///     r#type: None,
+    ///     size: None,
+    ///     checksum: None,
+    ///     description: None,
+    ///     deposition: None,
+    ///     unharmonized: None,
+    /// };
+    ///
+    /// assert!(params.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.r#type.is_none()
+            && self.size.is_none()
+            && self.checksum.is_none()
+            && self.description.is_none()
+            && self.deposition.is_none()
+            && self.unharmonized.is_none()
+    }
 }

--- a/packages/ccdi-server/src/responses/error.rs
+++ b/packages/ccdi-server/src/responses/error.rs
@@ -138,7 +138,7 @@ mod tests {
         ));
 
         let result = serde_json::to_string(&error)?;
-        assert_eq!(&result, "{\"errors\":[{\"kind\":\"InvalidParameters\",\"parameters\":null,\"reason\":\"Could not parse.\",\"message\":\" Invalid parameters: could not parse.\"}]}");
+        assert_eq!(&result, "{\"errors\":[{\"kind\":\"InvalidParameters\",\"parameters\":null,\"reason\":\"Could not parse.\",\"message\":\"Invalid parameters: could not parse.\"}]}");
 
         Ok(())
     }

--- a/packages/ccdi-server/src/responses/error/kind.rs
+++ b/packages/ccdi-server/src/responses/error/kind.rs
@@ -100,7 +100,7 @@ impl Kind {
     ///     String::from("Parameter not within serializable range.")
     /// );
     ///
-    /// assert_eq!(serde_json::to_string(&error)?, String::from("{\"kind\":\"InvalidParameters\",\"parameters\":null,\"reason\":\"Parameter not within serializable range.\",\"message\":\" Invalid parameters: parameter not within serializable range.\"}"));
+    /// assert_eq!(serde_json::to_string(&error)?, String::from("{\"kind\":\"InvalidParameters\",\"parameters\":null,\"reason\":\"Parameter not within serializable range.\",\"message\":\"Invalid parameters: parameter not within serializable range.\"}"));
     ///
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```

--- a/packages/ccdi-server/src/responses/error/kind/inner.rs
+++ b/packages/ccdi-server/src/responses/error/kind/inner.rs
@@ -249,7 +249,7 @@ impl std::fmt::Display for Inner {
                         write!(f, " {parameters}: {reason}")
                     }
                     None => {
-                        write!(f, " Invalid parameters: {reason}")
+                        write!(f, "Invalid parameters: {reason}")
                     }
                 }
             }

--- a/packages/ccdi-server/src/routes/sample.rs
+++ b/packages/ccdi-server/src/routes/sample.rs
@@ -4,7 +4,9 @@ use std::sync::Mutex;
 use std::sync::MutexGuard;
 
 use actix_web::get;
+use actix_web::post;
 use actix_web::web::Data;
+use actix_web::web::Json;
 use actix_web::web::Path;
 use actix_web::web::Query;
 use actix_web::web::ServiceConfig;
@@ -88,6 +90,7 @@ pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
         config
             .app_data(store)
             .service(sample_index)
+            .service(sample_filter)
             .service(samples_by_count)
             .service(sample_show)
             .service(sample_summary);
@@ -102,15 +105,6 @@ pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
 /// parameters by providing one or more of the pagination-related query
 /// parameters below.
 ///
-/// ### Filtering
-///
-/// All harmonized (top-level) and unharmonized (nested under the
-/// `metadata.unharmonized` key) metadata fields are filterable. Filtering is
-/// achieved by assigning a valid JSON value to a query parameter named after
-/// the field you want to filter by. The specific behavior of how the filter
-/// works is field-specific and is defined in the query parameter descriptions
-/// below.
-///
 /// ### Ordering
 ///
 /// This endpoint has default ordering requirements—those details are documented
@@ -119,32 +113,7 @@ pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
     get,
     path = "/sample",
     tag = "Sample",
-    params(
-        FilterSampleParams,
-        (
-            "metadata.unharmonized.<field>" = Option<String>,
-            Query,
-            nullable = false,
-            description = "All unharmonized fields should be filterable as
-            well:\n\n\
-            * Filtering on a singular field should include the `Sample` in \
-            the results if the query exactly matches the value of that field \
-            for the `Sample` (case-sensitive).\n\
-            * Filtering on field with multiple values should include the \
-            `Sample` in the results if the query exactly matches any of the \
-            values of the field for that `Sample` (case-sensitive).\n\
-            * Unlike harmonized fields, unharmonized fields must be prefixed \
-            with `metadata.unharmonized`.\n\n\
-            **Note:** this query parameter is intended to be symbolic of any \
-            unharmonized field. Because of limitations within Swagger UI, it \
-            will show up as a query parameter that can be optionally be \
-            submitted as part of a request within Swagger UI. Please keep in \
-            mind that the literal query parameter \
-            `?metadata.unharmonized.<field>=value` is not supported, so \
-            attempting to use it within Swagger UI will not work!"
-        ),
-        PaginationParams,
-    ),
+    params(PaginationParams),
     responses(
         (
             status = 200,
@@ -220,7 +189,127 @@ pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
 )]
 #[get("/sample")]
 pub async fn sample_index(
-    filter_params: Query<FilterSampleParams>,
+    pagination_params: Query<PaginationParams>,
+    samples: Data<Store>,
+) -> impl Responder {
+    respond_with_samples(None, pagination_params, samples).await
+}
+
+/// Filters the samples known by this server.
+///
+/// Calling this endpoint without providing at least one filter parameter is not
+/// allowed and will generate an error.
+///
+/// ### Pagination
+///
+/// This endpoint is paginated. Users may override the default pagination
+/// parameters by providing one or more of the pagination-related query
+/// parameters below.
+///
+/// ### Filtering
+///
+/// All harmonized (top-level) and unharmonized (nested under the
+/// `unharmonized` key) metadata fields are filterable. Filtering is
+/// achieved by assigning a valid JSON value to a query parameter named after
+/// the field you want to filter by. The specific behavior of how the filter
+/// works is field-specific and is defined in the query parameter descriptions
+/// below.
+///
+/// ### Ordering
+///
+/// This endpoint has default ordering requirements—those details are documented
+/// in the `responses::Samples` schema.
+#[utoipa::path(
+    post,
+    path = "/sample/filter",
+    tag = "Sample",
+    request_body = server::params::filter::Sample,
+    params(PaginationParams),
+    responses(
+        (
+            status = 200,
+            description = "Successful operation.",
+            body = responses::Samples,
+            headers(
+                (
+                    "link" = String,
+                    description = "Links to URLs that may be of interest \
+                    when paging through paginated responses. This header \
+                    contains two or more links of interest. The format of the \
+                    field is as follows: \
+                    \n\
+                    \n`Link: <URL>; rel=\"REL\"` \
+                    \n\
+                    ### Relationships\n\n\
+                    In the format above, `URL` represents a valid URL for \
+                    the link of interest and `REL` is one of four values: \n\
+                    - `first` (_Required_). A link to the first page in the \
+                    results (can be the same as `last` if there is only one \
+                    page).\n\
+                    - `last` (_Required_). A link to the first page in the \
+                    results (can be the same as `first` if there is only one \
+                    page).\n\
+                    - `next` (_Optional_). A link to the next page (if it \
+                    exists).\n\
+                    - `prev` (_Optional_). A link to the previous page (if it \
+                    exists).\n\n\
+                    ### Requirements\n\n\
+                    - This header _must_ provide links for at least the `first` \
+                    and `last` rels.\n \
+                    - The `prev` and `next` links must exist only (a) when there \
+                    are multiple pages in the result page set and (b) when the \
+                    current page is not the first or last page, respectively.\n\
+                    - This list of links is unordered.\n\n \
+                    ### Notes\n\n\
+                    - HTTP 1.1 and HTTP 2.0 dictate that response \
+                    headers are case insensitive. Though not required, we \
+                    recommend an all lowercase name of `link` for this \
+                    response header."
+                )
+            )
+        ),
+        (
+            status = 404,
+            description = "Not found.\nServers that cannot provide line-level \
+            data should use this response rather than Forbidden (403), as \
+            there is no level of authorization that would allow one to access \
+            the information included in the API.",
+            body = responses::Errors,
+            example = json!(
+                Errors::from(
+                    error::Kind::unshareable_data(
+                        String::from("samples"),
+                        String::from(
+                            "Our agreement with data providers prohibits us from sharing \
+                            line-level data."
+                        ),
+                    )
+                )
+            )
+        ),
+        (
+            status = 422,
+            description = "Invalid query or path parameters.",
+            body = responses::Errors,
+            example = json!(Errors::from(error::Kind::invalid_parameters(
+                Some(vec![String::from("page"), String::from("per_page")]),
+                String::from("unable to calculate offset")
+            )))
+        ),
+    )
+)]
+#[post("/sample/filter")]
+pub async fn sample_filter(
+    filter_params: Json<FilterSampleParams>,
+    pagination_params: Query<PaginationParams>,
+    samples: Data<Store>,
+) -> impl Responder {
+    respond_with_samples(Some(filter_params), pagination_params, samples).await
+}
+
+/// Responds with either the full set or a filtered set of samples.
+pub async fn respond_with_samples(
+    filter_params: Option<Json<FilterSampleParams>>,
     pagination_params: Query<PaginationParams>,
     samples: Data<Store>,
 ) -> impl Responder {
@@ -230,10 +319,29 @@ pub async fn sample_index(
     // sorted by identifier by default.
     samples.sort();
 
-    let samples = match filter::<Sample, FilterSampleParams>(samples, filter_params.0) {
-        Ok(samples) => samples,
-        Err(err) => return err.error_response(),
+    let samples = match filter_params {
+        Some(filter_params) => {
+            if filter_params.is_empty() {
+                return HttpResponse::UnprocessableEntity().json(Errors::from(
+                    error::Kind::invalid_parameters(
+                        None,
+                        String::from("Filter body parameters must contain at least one valid metadata field for this entity."),
+                    ),
+                ));
+            }
+
+            match filter::<Sample, FilterSampleParams>(samples, filter_params.0) {
+                Ok(samples) => samples,
+                Err(err) => return err.error_response(),
+            }
+        }
+        None => samples,
     };
+
+    if samples.is_empty() {
+        // If there are no entities to return, just return an empty array back.
+        return HttpResponse::Ok().json(Vec::<responses::Sample>::new());
+    }
 
     paginate::response::<Sample, Samples>(
         pagination_params.0,

--- a/swagger.yml
+++ b/swagger.yml
@@ -360,229 +360,12 @@ paths:
         parameters by providing one or more of the pagination-related query
         parameters below.
 
-        ### Filtering
-
-        All harmonized (top-level) and unharmonized (nested under the
-        `metadata.unharmonized` key) metadata fields are filterable. Filtering is
-        achieved by assigning a valid JSON value to a query parameter named after
-        the field you want to filter by. The specific behavior of how the filter
-        works is field-specific and is defined in the query parameter descriptions
-        below.
-
         ### Ordering
 
         This endpoint has default ordering requirements—those details are documented
         in the `responses::Subjects` schema.
       operationId: subject_index
       parameters:
-      - name: sex
-        in: query
-        description: |-
-          Matches any subject where the `sex` field exactly matches the specified
-          JSON value.
-
-          This parameter can either be a JSON string (surrounded by quotes) or
-          `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `sex` are included in the results.
-          - If a string is provided, all entries where `sex` exactly matches the
-          provided string are included in the results.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter `?sex="F"` to select all
-          subjects with a `sex` of `F`.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: race
-        in: query
-        description: |-
-          Matches subjects to their `race` value(s) according to the rules laid
-          out below.
-
-          This parameter can either be a JSON string or `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `race` are included in the results.
-          - If a string is provided, all entries where any `race` value exactly
-          matches the provided string are included in the results. Note that
-          this is effectively a logical OR (`||`) across any of the race values.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter `?race="American Indian or
-          Alaska Native"` to select any subjects where any race matches this
-          string.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: ethnicity
-        in: query
-        description: |-
-          Matches any subject where the `ethnicity` field exactly matches the
-          specified JSON value.
-
-          This parameter can either be a JSON string (surrounded by quotes) or
-          `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `ethnicity` are included in the results.
-          - If a string is provided, all entries where `ethnicity` exactly matches
-          the provided string are included in the results.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter `?ethnicity="Hispanic or
-          Latino"` to select all subjects with a `ethnicity` of `Hispanic or
-          Latino`.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: identifier
-        in: query
-        description: |-
-          Matches subjects to their `identifiers` value(s) according to the rules
-          laid out below.
-
-          This parameter can either be a JSON string or `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `identifiers` are included in the results.
-          - If a string is provided, all entries where any `identifiers` have a
-          name that exactly matches the provided string are included in the
-          results. Note that this is effectively a logical OR (`||`) across any
-          of the identifier name values.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter
-          `?identifier="Subject-OZNL7P47"` to select any subjects where any
-          identifiers matches this string.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: vital_status
-        in: query
-        description: |-
-          Matches any subject where the `vital_status` field exactly matches the
-          specified JSON value.
-
-          This parameter can either be a JSON string (surrounded by quotes) or
-          `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `vital_status` are included in the results.
-          - If a string is provided, all entries where `vital_status` exactly
-          matches the provided string are included in the results.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter `?vital_status="Alive"` to
-          select all subjects with a `vital_status` of `Alive`.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: age_at_vital_status
-        in: query
-        description: |-
-          Matches any subject where the `age_at_vital_status` field exactly
-          matches the specified JSON value.
-
-          This parameter can either be a JSON number (surrounded by quotes) or
-          `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `age_at_vital_status` are included in the results.
-          - If a number is provided, all entries where `age_at_vital_status`
-          exactly matches the provided number are included in the results.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter `?age_at_vital_status=365.25`
-          to select all subjects with a `age_at_vital_status` of `365.25`.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: deposition
-        in: query
-        description: |-
-          Matches subjects to their `depositions` value(s) according to the rules
-          laid out below.
-
-          This parameter can either be a JSON string or `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `depositions` are included in the results.
-          - If a string is provided, all entries where any `depositions` value
-          exactly matches the provided string are included in the results. Note
-          that this is effectively a logical OR (`||`) across any of the
-          deposition values.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter
-          `?deposition="phs000000.v1.p1"` to select any subjects where any
-          deposition value matches this string.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: metadata.unharmonized.<field>
-        in: query
-        description: |-
-          All unharmonized fields should be filterable as well:
-
-          * Filtering on a singular field should include the `Subject` in the results if the query exactly matches the value of that field for the `Subject` (case-sensitive).
-          * Filtering on field with multiple values should include the `Subject` in the results if the query exactly matches any of the values of the field for that `Subject` (case-sensitive).
-          * Unlike harmonized fields, unharmonized fields must be prefixed with `metadata.unharmonized`.
-
-          **Note:** this query parameter is intended to be symbolic of any unharmonized field. Because of limitations within Swagger UI, it will show up as a query parameter that can be optionally be submitted as part of a request within Swagger UI. Please keep in mind that the literal query parameter `?metadata.unharmonized.<field>=value` is not supported, so attempting to use it within Swagger UI will not work!
-        required: false
-        schema:
-          type: string
       - name: page
         in: query
         description: |-
@@ -607,6 +390,108 @@ paths:
         schema:
           type: integer
           minimum: 0
+      responses:
+        '200':
+          description: Successful operation.
+          headers:
+            link:
+              schema:
+                type: string
+              description: "Links to URLs that may be of interest when paging through paginated responses. This header contains two or more links of interest. The format of the field is as follows: \n\n`Link: <URL>; rel=\"REL\"` \n### Relationships\n\nIn the format above, `URL` represents a valid URL for the link of interest and `REL` is one of four values: \n- `first` (_Required_). A link to the first page in the results (can be the same as `last` if there is only one page).\n- `last` (_Required_). A link to the first page in the results (can be the same as `first` if there is only one page).\n- `next` (_Optional_). A link to the next page (if it exists).\n- `prev` (_Optional_). A link to the previous page (if it exists).\n\n### Requirements\n\n- This header _must_ provide links for at least the `first` and `last` rels.\n - The `prev` and `next` links must exist only (a) when there are multiple pages in the result page set and (b) when the current page is not the first or last page, respectively.\n- This list of links is unordered.\n\n ### Notes\n\n- HTTP 1.1 and HTTP 2.0 dictate that response headers are case insensitive. Though not required, we recommend an all lowercase name of `link` for this response header."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responses.Subjects'
+        '404':
+          description: |-
+            Not found.
+            Servers that cannot provide line-level data should use this response rather than Forbidden (403), as there is no level of authorization that would allow one to access the information included in the API.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responses.Errors'
+              example:
+                errors:
+                - kind: UnshareableData
+                  entity: Subjects
+                  reason: Our agreement with data providers prohibits us from sharing line-level data.
+                  message: 'Unable to share data for subjects: our agreement with data providers prohibits us from sharing line-level data.'
+        '422':
+          description: Invalid query or path parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responses.Errors'
+              example:
+                errors:
+                - kind: InvalidParameters
+                  parameters:
+                  - page
+                  - per_page
+                  reason: Unable to calculate offset.
+                  message: 'Invalid value for parameters ''page'' and ''per_page'': unable to calculate offset.'
+  /subject/filter:
+    post:
+      tags:
+      - Subject
+      summary: Filters the subjects known by this server.
+      description: |-
+        Filters the subjects known by this server.
+
+        Calling this endpoint without providing at least one filter parameter is not
+        allowed and will generate an error.
+
+        ### Pagination
+
+        This endpoint is paginated. Users may override the default pagination
+        parameters by providing one or more of the pagination-related query
+        parameters below.
+
+        ### Filtering
+
+        All harmonized (top-level) and unharmonized (nested under the
+        `unharmonized` key) metadata fields are filterable. Filtering is
+        achieved by assigning a valid JSON value to a query parameter named after
+        the field you want to filter by. The specific behavior of how the filter
+        works is field-specific and is defined in the query parameter descriptions
+        below.
+
+        ### Ordering
+
+        This endpoint has default ordering requirements—those details are documented
+        in the `responses::Subjects` schema.
+      operationId: subject_filter
+      parameters:
+      - name: page
+        in: query
+        description: |-
+          The page to retrieve.
+
+          This is a 1-based index of a page within a page set. The value of `page`
+          **must** default to `1` when this parameter is not provided.
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+      - name: per_page
+        in: query
+        description: |-
+          The number of results per page.
+
+          Each server can select its own default value for `per_page` when this
+          parameter is not provided. That said, the convention within the
+          community is to use `100` as a default value if any value is equally
+          reasonable.
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/server.params.filter.Subject'
+        required: true
       responses:
         '200':
           description: Successful operation.
@@ -761,346 +646,12 @@ paths:
         parameters by providing one or more of the pagination-related query
         parameters below.
 
-        ### Filtering
-
-        All harmonized (top-level) and unharmonized (nested under the
-        `metadata.unharmonized` key) metadata fields are filterable. Filtering is
-        achieved by assigning a valid JSON value to a query parameter named after
-        the field you want to filter by. The specific behavior of how the filter
-        works is field-specific and is defined in the query parameter descriptions
-        below.
-
         ### Ordering
 
         This endpoint has default ordering requirements—those details are documented
         in the `responses::Samples` schema.
       operationId: sample_index
       parameters:
-      - name: age_at_diagnosis
-        in: query
-        description: |-
-          Matches any sample where the `age_at_diagnosis` field exactly matches
-          the specified JSON value.
-
-          This parameter can either be a JSON number or `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `age_at_diagnosis` are included in the results.
-          - If a number is provided, all entries where `age_at_diagnosis` exactly
-          matches the provided number are included in the results.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter `?age_at_diagnosis=365.25` to
-          select all samples with a `age_at_diagnosis` of `365.25`.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: diagnosis
-        in: query
-        description: |-
-          Matches samples to their `diagnosis` value(s) according to the rules
-          laid out below.
-
-          This parameter can either be a JSON string or `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `diagnosis` are included in the results.
-          - If a string is provided, all entries where any `diagnosis` value
-          contains the provided string are included in the results. Note that
-          this is effectively a logical OR (`||`) across any of the diagnosis
-          values containing the substring.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter `?diagnosis="sarcoma"` to
-          select any samples where any diagnosis value contains the string
-          `sarcoma`.
-
-          **Note:** this filter parameter contains non-standard filtering
-          criteria—implementors should carefully read the description above.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: disease_phase
-        in: query
-        description: |-
-          Matches any sample where the `disease_phase` field exactly matches the
-          specified JSON value.
-
-          This parameter can either be a JSON string (surrounded by quotes) or
-          `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `disease_phase` are included in the results.
-          - If a string is provided, all entries where `disease_phase` exactly
-          matches the provided string are included in the results.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter `?disease_phase="Initial
-          Diagnosis"` to select all samples with a `disease_phase` of `Initial
-          Diagnosis`.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: tissue_type
-        in: query
-        description: |-
-          Matches any sample where the `tissue_type` field exactly matches the
-          specified JSON value.
-
-          This parameter can either be a JSON string (surrounded by quotes) or
-          `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `tissue_type` are included in the results.
-          - If a string is provided, all entries where `tissue_type` exactly
-          matches the provided string are included in the results.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter `?tissue_type="Unspecified"`
-          to select all samples with a `tissue_type` of `Unspecified`.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: tumor_classification
-        in: query
-        description: |-
-          Matches any sample where the `tumor_classification` field exactly
-          matches the specified JSON value.
-
-          This parameter can either be a JSON string (surrounded by quotes) or
-          `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `tumor_classification` are included in the
-          results.
-          - If a string is provided, all entries where `tumor_classification`
-          exactly matches the provided string are included in the results.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter
-          `?tumor_classification="Regional"` to select all samples with a
-          `tumor_classification` of `Regional`.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: tumor_tissue_morphology
-        in: query
-        description: |-
-          Matches samples to their `tumor_tissue_morphology` value(s) according to
-          the rules laid out below.
-
-          This parameter can either be a JSON string or `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `tumor_tissue_morphology` are included in the
-          results.
-          - If a string is provided, all entries where any
-          `tumor_tissue_morphology` value exactly matches the provided string
-          are included in the results. Note that this is effectively a logical
-          OR (`||`) across any of the tumor tissue morphology values.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter
-          `?tumor_tissue_morphology="8000/0"` to select any samples where any
-          tumor tissue morphology matches this string.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: age_at_collection
-        in: query
-        description: |-
-          Matches any sample where the `age_at_collection` field exactly matches
-          the specified JSON value.
-
-          This parameter can either be a JSON number or `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `age_at_collection` are included in the results.
-          - If a number is provided, all entries where `age_at_collection` exactly
-          matches the provided number are included in the results.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter `?age_at_collection=365.25` to
-          select all samples with a `age_at_collection` of `365.25`.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: library_strategy
-        in: query
-        description: |-
-          Matches any sample where the `library_strategy` field exactly matches
-          the specified JSON value.
-
-          This parameter can either be a JSON string (surrounded by quotes) or
-          `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `library_strategy` are included in the results.
-          - If a string is provided, all entries where `library_strategy` exactly
-          matches the provided string are included in the results.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter `?library_strategy="DNA-Seq"`
-          to select all samples with a `library_strategy` of `DNA-Seq`.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: preservation_method
-        in: query
-        description: |-
-          Matches any sample where the `preservation_method` field exactly matches
-          the specified JSON value.
-
-          This parameter can either be a JSON string (surrounded by quotes) or
-          `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `preservation_method` are included in the results.
-          - If a string is provided, all entries where `preservation_method`
-          exactly matches the provided string are included in the results.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter
-          `?preservation_method="Cryopreserved"` to select all samples with a
-          `preservation_method` of `Cryopreserved`.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: identifier
-        in: query
-        description: |-
-          Matches samples to their `identifiers` value(s) according to the rules
-          laid out below.
-
-          This parameter can either be a JSON string or `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `identifiers` are included in the results.
-          - If a string is provided, all entries where any `identifiers` have a
-          name that exactly matches the provided string are included in the
-          results. Note that this is effectively a logical OR (`||`) across any
-          of the identifier name values.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter
-          `?identifier="Sample-F62VO0JV"` to select any samples where any
-          identifiers matches this string.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: deposition
-        in: query
-        description: |-
-          Matches samples to their `depositions` value(s) according to the rules
-          laid out below.
-
-          This parameter can either be a JSON string or `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `depositions` are included in the results.
-          - If a string is provided, all entries where any `depositions` value
-          exactly matches the provided string are included in the results. Note
-          that this is effectively a logical OR (`||`) across any of the
-          deposition values.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter
-          `?deposition="phs000000.v1.p1"` to select any samples where any
-          deposition value matches this string.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: metadata.unharmonized.<field>
-        in: query
-        description: |-
-          All unharmonized fields should be filterable as
-                      well:
-
-          * Filtering on a singular field should include the `Sample` in the results if the query exactly matches the value of that field for the `Sample` (case-sensitive).
-          * Filtering on field with multiple values should include the `Sample` in the results if the query exactly matches any of the values of the field for that `Sample` (case-sensitive).
-          * Unlike harmonized fields, unharmonized fields must be prefixed with `metadata.unharmonized`.
-
-          **Note:** this query parameter is intended to be symbolic of any unharmonized field. Because of limitations within Swagger UI, it will show up as a query parameter that can be optionally be submitted as part of a request within Swagger UI. Please keep in mind that the literal query parameter `?metadata.unharmonized.<field>=value` is not supported, so attempting to use it within Swagger UI will not work!
-        required: false
-        schema:
-          type: string
       - name: page
         in: query
         description: |-
@@ -1125,6 +676,108 @@ paths:
         schema:
           type: integer
           minimum: 0
+      responses:
+        '200':
+          description: Successful operation.
+          headers:
+            link:
+              schema:
+                type: string
+              description: "Links to URLs that may be of interest when paging through paginated responses. This header contains two or more links of interest. The format of the field is as follows: \n\n`Link: <URL>; rel=\"REL\"` \n### Relationships\n\nIn the format above, `URL` represents a valid URL for the link of interest and `REL` is one of four values: \n- `first` (_Required_). A link to the first page in the results (can be the same as `last` if there is only one page).\n- `last` (_Required_). A link to the first page in the results (can be the same as `first` if there is only one page).\n- `next` (_Optional_). A link to the next page (if it exists).\n- `prev` (_Optional_). A link to the previous page (if it exists).\n\n### Requirements\n\n- This header _must_ provide links for at least the `first` and `last` rels.\n - The `prev` and `next` links must exist only (a) when there are multiple pages in the result page set and (b) when the current page is not the first or last page, respectively.\n- This list of links is unordered.\n\n ### Notes\n\n- HTTP 1.1 and HTTP 2.0 dictate that response headers are case insensitive. Though not required, we recommend an all lowercase name of `link` for this response header."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responses.Samples'
+        '404':
+          description: |-
+            Not found.
+            Servers that cannot provide line-level data should use this response rather than Forbidden (403), as there is no level of authorization that would allow one to access the information included in the API.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responses.Errors'
+              example:
+                errors:
+                - kind: UnshareableData
+                  entity: Samples
+                  reason: Our agreement with data providers prohibits us from sharing line-level data.
+                  message: 'Unable to share data for samples: our agreement with data providers prohibits us from sharing line-level data.'
+        '422':
+          description: Invalid query or path parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responses.Errors'
+              example:
+                errors:
+                - kind: InvalidParameters
+                  parameters:
+                  - page
+                  - per_page
+                  reason: Unable to calculate offset.
+                  message: 'Invalid value for parameters ''page'' and ''per_page'': unable to calculate offset.'
+  /sample/filter:
+    post:
+      tags:
+      - Sample
+      summary: Filters the samples known by this server.
+      description: |-
+        Filters the samples known by this server.
+
+        Calling this endpoint without providing at least one filter parameter is not
+        allowed and will generate an error.
+
+        ### Pagination
+
+        This endpoint is paginated. Users may override the default pagination
+        parameters by providing one or more of the pagination-related query
+        parameters below.
+
+        ### Filtering
+
+        All harmonized (top-level) and unharmonized (nested under the
+        `unharmonized` key) metadata fields are filterable. Filtering is
+        achieved by assigning a valid JSON value to a query parameter named after
+        the field you want to filter by. The specific behavior of how the filter
+        works is field-specific and is defined in the query parameter descriptions
+        below.
+
+        ### Ordering
+
+        This endpoint has default ordering requirements—those details are documented
+        in the `responses::Samples` schema.
+      operationId: sample_filter
+      parameters:
+      - name: page
+        in: query
+        description: |-
+          The page to retrieve.
+
+          This is a 1-based index of a page within a page set. The value of `page`
+          **must** default to `1` when this parameter is not provided.
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+      - name: per_page
+        in: query
+        description: |-
+          The number of results per page.
+
+          Each server can select its own default value for `per_page` when this
+          parameter is not provided. That said, the convention within the
+          community is to use `100` as a default value if any value is equally
+          reasonable.
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/server.params.filter.Sample'
+        required: true
       responses:
         '200':
           description: Successful operation.
@@ -1279,176 +932,12 @@ paths:
         parameters by providing one or more of the pagination-related query
         parameters below.
 
-        ### Filtering
-
-        All harmonized (top-level) and unharmonized (nested under the
-        `metadata.unharmonized` key) metadata fields are filterable. Filtering is
-        achieved by assigning a valid JSON value to a query parameter named after
-        the field you want to filter by. The specific behavior of how the filter
-        works is field-specific and is defined in the query parameter descriptions
-        below.
-
         ### Ordering
 
         This endpoint has default ordering requirements—those details are documented
         in the `responses::Files` schema.
       operationId: file_index
       parameters:
-      - name: type
-        in: query
-        description: |-
-          Matches any file where the `type` field exactly matches the specified
-          JSON value.
-
-          This parameter can either be a JSON string (surrounded by quotes) or
-          `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `type` are included in the results.
-          - If a string is provided, all entries where `type` exactly matches the
-          provided string are included in the results.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter `?type="TXT"` to select all
-          files with a type of `TXT`.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: size
-        in: query
-        description: |-
-          Matches any file where the `size` field exactly matches the specified
-          JSON value.
-
-          This parameter can either be a JSON number or `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `size` are included in the results.
-          - If a number is provided, all entries where `size` exactly matches the
-          provided number are included in the results.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter `?size=12345` to select all
-          files with a size of `12345`.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: checksum
-        in: query
-        description: |-
-          Matches files to their `checksums` value(s) according to the rules laid
-          out below.
-
-          This parameter can either be a JSON string or `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `checksums` are included in the results.
-          - If a string is provided, all entries where any `checksums` value
-          exactly matches the provided string are included in the results. Note
-          that this is effectively a logical OR (`||`) across any of the
-          checksum values.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter
-          `?checksum="A9781F66C9C5C9DA8837132FFEB08CA"` to select any files where
-          any checksum matches this string.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: description
-        in: query
-        description: |-
-          Matches files to their `description` value according to the rules laid
-          out below.
-
-          This parameter can either be a JSON string (surrounded by quotes) or
-          `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `description` are included in the results.
-          - If a string is provided, all entries where the `description` contains
-          the string provided (case-sensitive) are included in the results.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter `?description="hello"` to
-          select all files where the description includes the substring `hello`.
-
-          **Note:** this filter parameter contains non-standard filtering
-          criteria—implementors should carefully read the description above.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: deposition
-        in: query
-        description: |-
-          Matches files to their `depositions` value(s) according to the rules
-          laid out below.
-
-          This parameter can either be a JSON string or `null`.
-
-          - If `null` is provided as the value, all entries that are either (a)
-          missing a metadata block or (b) contain a metadata block but are
-          missing a value for `depositions` are included in the results.
-          - If a string is provided, all entries where any `depositions` value
-          exactly matches the provided string are included in the results. Note
-          that this is effectively a logical OR (`||`) across any of the
-          deposition values.
-
-          If a query parameter value is provided that is not able to be parsed as
-          a JSON value, an error should be returned indicating this. Further, if a
-          JSON value is able to be parsed, but the value is not one of the
-          acceptable value types above, an error should be returned indicating
-          this.
-
-          For example, you might provide the filter
-          `?deposition="phs000000.v1.p1"` to select any files where any deposition
-          value matches this string.
-        required: false
-        schema:
-          type: string
-          nullable: true
-      - name: metadata.unharmonized.<field>
-        in: query
-        description: |-
-          All unharmonized fields should be filterable as
-                      well:
-
-          * Filtering on a singular field should include the `File` in the results if the query exactly matches the value of that field for the `File` (case-sensitive).
-          * Filtering on field with multiple values should include the `File` in the results if the query exactly matches any of the values of the field for that `File` (case-sensitive).
-          * Unlike harmonized fields, unharmonized fields must be prefixed with `metadata.unharmonized`.
-
-          **Note:** this query parameter is intended to be symbolic of any unharmonized field. Because of limitations within Swagger UI, it will show up as a query parameter that can be optionally be submitted as part of a request within Swagger UI. Please keep in mind that the literal query parameter `?metadata.unharmonized.<field>=value` is not supported, so attempting to use it within Swagger UI will not work!
-        required: false
-        schema:
-          type: string
       - name: page
         in: query
         description: |-
@@ -1501,6 +990,108 @@ paths:
                   message: 'Unable to share data for files: our agreement with data providers prohibits us from sharing file-level data.'
         '422':
           description: Invalid query or path parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responses.Errors'
+              example:
+                errors:
+                - kind: InvalidParameters
+                  parameters:
+                  - page
+                  - per_page
+                  reason: Unable to calculate offset.
+                  message: 'Invalid value for parameters ''page'' and ''per_page'': unable to calculate offset.'
+  /file/filter:
+    post:
+      tags:
+      - File
+      summary: Filters the files known by this server.
+      description: |-
+        Filters the files known by this server.
+
+        Calling this endpoint without providing at least one filter parameter is not
+        allowed and will generate an error.
+
+        ### Pagination
+
+        This endpoint is paginated. Users may override the default pagination
+        parameters by providing one or more of the pagination-related query
+        parameters below.
+
+        ### Filtering
+
+        All harmonized (top-level) and unharmonized (nested under the
+        `unharmonized` key) metadata fields are filterable. Filtering is
+        achieved by assigning a valid JSON value to a query parameter named after
+        the field you want to filter by. The specific behavior of how the filter
+        works is field-specific and is defined in the query parameter descriptions
+        below.
+
+        ### Ordering
+
+        This endpoint has default ordering requirements—those details are documented
+        in the `responses::Files` schema.
+      operationId: file_filter
+      parameters:
+      - name: page
+        in: query
+        description: |-
+          The page to retrieve.
+
+          This is a 1-based index of a page within a page set. The value of `page`
+          **must** default to `1` when this parameter is not provided.
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+      - name: per_page
+        in: query
+        description: |-
+          The number of results per page.
+
+          Each server can select its own default value for `per_page` when this
+          parameter is not provided. That said, the convention within the
+          community is to use `100` as a default value if any value is equally
+          reasonable.
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/server.params.filter.File'
+        required: true
+      responses:
+        '200':
+          description: Successful operation.
+          headers:
+            link:
+              schema:
+                type: string
+              description: "Links to URLs that may be of interest when paging through paginated responses. This header contains two or more links of interest. The format of the field is as follows: \n\n`Link: <URL>; rel=\"REL\"` \n### Relationships\n\nIn the format above, `URL` represents a valid URL for the link of interest and `REL` is one of four values: \n- `first` (_Required_). A link to the first page in the results (can be the same as `last` if there is only one page).\n- `last` (_Required_). A link to the first page in the results (can be the same as `first` if there is only one page).\n- `next` (_Optional_). A link to the next page (if it exists).\n- `prev` (_Optional_). A link to the previous page (if it exists).\n\n### Requirements\n\n- This header _must_ provide links for at least the `first` and `last` rels.\n - The `prev` and `next` links must exist only (a) when there are multiple pages in the result page set and (b) when the current page is not the first or last page, respectively.\n- This list of links is unordered.\n\n ### Notes\n\n- HTTP 1.1 and HTTP 2.0 dictate that response headers are case insensitive. Though not required, we recommend an all lowercase name of `link` for this response header."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responses.Files'
+        '404':
+          description: |-
+            Not found.
+            Servers that cannot provide line-level data should use this response rather than Forbidden (403), as there is no level of authorization that would allow one to access the information included in the API.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responses.Errors'
+              example:
+                errors:
+                - kind: UnshareableData
+                  entity: Files
+                  reason: Our agreement with data providers prohibits us from sharing file-level data.
+                  message: 'Unable to share data for files: our agreement with data providers prohibits us from sharing file-level data.'
+        '422':
+          description: Invalid query, path, or JSON parameters.
           content:
             application/json:
               schema:
@@ -4836,6 +4427,604 @@ components:
         total:
           type: integer
           minimum: 0
+    server.params.filter.File:
+      type: object
+      description: |-
+        Parameters for filtering files.
+
+        Parameters for filtering files are declared as JSON objects. For each key
+        provided that matches a valid metadata field in a file, the endpoint will
+        filter the results according to the rules described for each field and
+        intersect the results.
+
+        Note that, when strings are provided, matching is case-sensitive unless
+        otherwise stated. At least one valid parameter for files must be included in
+        the `/file/filter` request.
+      properties:
+        type:
+          type: string
+          description: |-
+            Matches any file where the `type` field exactly matches the specified
+            value.
+
+            This parameter can either be a JSON string (surrounded by quotes) or
+            `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `type` are included in the results.
+            - If a string is provided, all entries where `type` exactly matches the
+            provided string are included in the results.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "type": "TXT" }` to select
+            all files with a type of `TXT`.
+          nullable: true
+        size:
+          type: integer
+          description: |-
+            Matches any file where the `size` field exactly matches the specified
+            value.
+
+            This parameter can either be a JSON number or `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `size` are included in the results.
+            - If a number is provided, all entries where `size` exactly matches the
+            provided number are included in the results.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "size": 12345 }` to select
+            all files with a size of `12345`.
+          nullable: true
+          minimum: 0
+        checksum:
+          type: string
+          description: |-
+            Matches files to their `checksums` value(s) according to the rules laid
+            out below.
+
+            This parameter can either be a JSON string or `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `checksums` are included in the results.
+            - If a string is provided, all entries where any `checksums` value
+            exactly matches the provided string are included in the results. Note
+            that this is effectively a logical OR (`||`) across any of the
+            checksum values.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "checksum":
+            "A9781F66C9C5C9DA8837132FFEB08CA" }` to select any files where any
+            checksum matches this string.
+          nullable: true
+        description:
+          type: string
+          description: |-
+            Matches files to their `description` value according to the rules laid
+            out below.
+
+            This parameter can either be a JSON string (surrounded by quotes) or
+            `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `description` are included in the results.
+            - If a string is provided, all entries where the `description` contains
+            the string provided (case-sensitive) are included in the results.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "description": "hello" }`
+            to select all files where the description includes the substring
+            `hello`.
+
+            **Note:** this filter parameter contains non-standard filtering
+            criteria—implementors should carefully read the description above.
+          nullable: true
+        deposition:
+          type: string
+          description: |-
+            Matches files to their `depositions` value(s) according to the rules
+            laid out below.
+
+            This parameter can either be a JSON string or `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `depositions` are included in the results.
+            - If a string is provided, all entries where any `depositions` value
+            exactly matches the provided string are included in the results. Note
+            that this is effectively a logical OR (`||`) across any of the
+            deposition values.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "deposition":
+            "phs000000.v1.p1" }` to select any files where any deposition value
+            matches this string.
+          nullable: true
+        unharmonized:
+          type: object
+          description: |-
+            All unharmonized fields should be filterable as well:
+
+            * Filtering on a singular field should include the `File` in the results
+            if the query exactly matches the value of that field for the `File`
+            (case-sensitive).
+            * Filtering on field with multiple values should include the `File` in
+            the results if the query exactly matches any of the values of the field
+            for that `File` (case-sensitive).
+          additionalProperties: {}
+          nullable: true
+    server.params.filter.Sample:
+      type: object
+      description: |-
+        Parameters for filtering samples.
+
+        Parameters for filtering samples are declared as JSON objects. For each key
+        provided that matches a valid metadata field in a sample, the endpoint will
+        filter the results according to the rules described for each field and
+        intersect the results.
+
+        Note that, when strings are provided, matching is case-sensitive unless
+        otherwise stated. At least one valid parameter for samples must be included
+        in the `/sample/filter` request.
+      properties:
+        age_at_diagnosis:
+          type: number
+          format: double
+          description: |-
+            Matches any sample where the `age_at_diagnosis` field exactly matches
+            the specified value.
+
+            This parameter can either be a JSON number or `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `age_at_diagnosis` are included in the results.
+            - If a number is provided, all entries where `age_at_diagnosis` exactly
+            matches the provided number are included in the results.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "age_at_diagnosis": 365.25
+            }` to select all samples with a `age_at_diagnosis` of `365.25`.
+          nullable: true
+        diagnosis:
+          type: string
+          description: |-
+            Matches samples to their `diagnosis` value(s) according to the rules
+            laid out below.
+
+            This parameter can either be a JSON string or `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `diagnosis` are included in the results.
+            - If a string is provided, all entries where any `diagnosis` value
+            contains the provided string are included in the results. Note that
+            this is effectively a logical OR (`||`) across any of the diagnosis
+            values containing the substring.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "diagnosis": "sarcoma" }`
+            to select any samples where any diagnosis value contains the string
+            `sarcoma`.
+
+            **Note:** this filter parameter contains non-standard filtering
+            criteria—implementors should carefully read the description above.
+          nullable: true
+        disease_phase:
+          type: string
+          description: |-
+            Matches any sample where the `disease_phase` field exactly matches the
+            specified value.
+
+            This parameter can either be a JSON string (surrounded by quotes) or
+            `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `disease_phase` are included in the results.
+            - If a string is provided, all entries where `disease_phase` exactly
+            matches the provided string are included in the results.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "disease_phase": "Initial
+            Diagnosis" }` to select all samples with a `disease_phase` of `Initial
+            Diagnosis`.
+          nullable: true
+        tissue_type:
+          type: string
+          description: |-
+            Matches any sample where the `tissue_type` field exactly matches the
+            specified value.
+
+            This parameter can either be a JSON string (surrounded by quotes) or
+            `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `tissue_type` are included in the results.
+            - If a string is provided, all entries where `tissue_type` exactly
+            matches the provided string are included in the results.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "tissue_type":
+            "Unspecified" }` to select all samples with a `tissue_type` of
+            `Unspecified`.
+          nullable: true
+        tumor_classification:
+          type: string
+          description: |-
+            Matches any sample where the `tumor_classification` field exactly
+            matches the specified value.
+
+            This parameter can either be a JSON string (surrounded by quotes) or
+            `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `tumor_classification` are included in the
+            results.
+            - If a string is provided, all entries where `tumor_classification`
+            exactly matches the provided string are included in the results.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "tumor_classification":
+            "Regional" }` to select all samples with a `tumor_classification` of
+            `Regional`.
+          nullable: true
+        tumor_tissue_morphology:
+          type: string
+          description: |-
+            Matches samples to their `tumor_tissue_morphology` value(s) according to
+            the rules laid out below.
+
+            This parameter can either be a JSON string or `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `tumor_tissue_morphology` are included in the
+            results.
+            - If a string is provided, all entries where any
+            `tumor_tissue_morphology` value exactly matches the provided string
+            are included in the results. Note that this is effectively a logical
+            OR (`||`) across any of the tumor tissue morphology values.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "tumor_tissue_morphology":
+            "8000/0" }` to select any samples where any tumor tissue morphology
+            matches this string.
+          nullable: true
+        age_at_collection:
+          type: number
+          format: double
+          description: |-
+            Matches any sample where the `age_at_collection` field exactly matches
+            the specified value.
+
+            This parameter can either be a JSON number or `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `age_at_collection` are included in the results.
+            - If a number is provided, all entries where `age_at_collection` exactly
+            matches the provided number are included in the results.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "age_at_collection": 365.25
+            }` to select all samples with a `age_at_collection` of `365.25`.
+          nullable: true
+        library_strategy:
+          type: string
+          description: |-
+            Matches any sample where the `library_strategy` field exactly matches
+            the specified value.
+
+            This parameter can either be a JSON string (surrounded by quotes) or
+            `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `library_strategy` are included in the results.
+            - If a string is provided, all entries where `library_strategy` exactly
+            matches the provided string are included in the results.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "library_strategy":
+            "DNA-Seq" }` to select all samples with a `library_strategy` of
+            `DNA-Seq`.
+          nullable: true
+        preservation_method:
+          type: string
+          description: |-
+            Matches any sample where the `preservation_method` field exactly matches
+            the specified value.
+
+            This parameter can either be a JSON string (surrounded by quotes) or
+            `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `preservation_method` are included in the results.
+            - If a string is provided, all entries where `preservation_method`
+            exactly matches the provided string are included in the results.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "preservation_method":
+            "Cryopreserved" }` to select all samples with a `preservation_method` of
+            `Cryopreserved`.
+          nullable: true
+        identifier:
+          type: string
+          description: |-
+            Matches samples to their `identifiers` value(s) according to the rules
+            laid out below.
+
+            This parameter can either be a JSON string or `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `identifiers` are included in the results.
+            - If a string is provided, all entries where any `identifiers` have a
+            name that exactly matches the provided string are included in the
+            results. Note that this is effectively a logical OR (`||`) across any
+            of the identifier name values.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "identifier":
+            "Sample-F62VO0JV" }` to select any samples where any identifiers matches
+            this string.
+          nullable: true
+        deposition:
+          type: string
+          description: |-
+            Matches samples to their `depositions` value(s) according to the rules
+            laid out below.
+
+            This parameter can either be a JSON string or `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `depositions` are included in the results.
+            - If a string is provided, all entries where any `depositions` value
+            exactly matches the provided string are included in the results. Note
+            that this is effectively a logical OR (`||`) across any of the
+            deposition values.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "deposition":
+            "phs000000.v1.p1" }` to select any samples where any deposition value
+            matches this string.
+          nullable: true
+        unharmonized:
+          type: object
+          description: |-
+            All unharmonized fields should be filterable as well:
+
+            * Filtering on a singular field should include the `Sample` in the
+            results if the query exactly matches the value of that field for the
+            `Sample` (case-sensitive).
+            * Filtering on field with multiple values should include the `Sample` in
+            the results if the query exactly matches any of the values of the field
+            for that `Sample` (case-sensitive).
+          additionalProperties: {}
+          nullable: true
+    server.params.filter.Subject:
+      type: object
+      description: |-
+        Parameters for filtering subjects.
+
+        Parameters for filtering subjects are declared as JSON objects. For each key
+        provided that matches a valid metadata field in a subject, the endpoint will
+        filter the results according to the rules described for each field and
+        intersect the results.
+
+        Note that, when strings are provided, matching is case-sensitive unless
+        otherwise stated. At least one valid parameter for subjects must be included
+        in the `/subject/filter` request.
+      properties:
+        sex:
+          type: string
+          description: |-
+            Matches any subject where the `sex` field exactly matches the specified
+            value.
+
+            This parameter can either be a JSON string (surrounded by quotes) or
+            `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `sex` are included in the results.
+            - If a string is provided, all entries where `sex` exactly matches the
+            provided string are included in the results.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "sex": "F" }` to select all
+            subjects with a `sex` of `F`.
+          nullable: true
+        race:
+          type: string
+          description: |-
+            Matches subjects to their `race` value(s) according to the rules laid
+            out below.
+
+            This parameter can either be a JSON string or `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `race` are included in the results.
+            - If a string is provided, all entries where any `race` value exactly
+            matches the provided string are included in the results. Note that
+            this is effectively a logical OR (`||`) across any of the race values.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "race": "American Indian or
+            Alaska Native" }` to select any subjects where any race matches this
+            string.
+          nullable: true
+        ethnicity:
+          type: string
+          description: |-
+            Matches any subject where the `ethnicity` field exactly matches the
+            specified value.
+
+            This parameter can either be a JSON string (surrounded by quotes) or
+            `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `ethnicity` are included in the results.
+            - If a string is provided, all entries where `ethnicity` exactly matches
+            the provided string are included in the results.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "ethnicity": "Hispanic or
+            Latino" }` to select all subjects with a `ethnicity` of `Hispanic or
+            Latino`.
+          nullable: true
+        identifier:
+          type: string
+          description: |-
+            Matches subjects to their `identifiers` value(s) according to the rules
+            laid out below.
+
+            This parameter can either be a JSON string or `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `identifiers` are included in the results.
+            - If a string is provided, all entries where any `identifiers` have a
+            name that exactly matches the provided string are included in the
+            results. Note that this is effectively a logical OR (`||`) across any
+            of the identifier name values.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "identifier":
+            "Subject-OZNL7P47" }` to select any subjects where any identifiers
+            matches this string.
+          nullable: true
+        vital_status:
+          type: string
+          description: |-
+            Matches any subject where the `vital_status` field exactly matches the
+            specified value.
+
+            This parameter can either be a JSON string (surrounded by quotes) or
+            `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `vital_status` are included in the results.
+            - If a string is provided, all entries where `vital_status` exactly
+            matches the provided string are included in the results.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "vital_status": "Alive" }`
+            to select all subjects with a `vital_status` of `Alive`.
+          nullable: true
+        age_at_vital_status:
+          type: number
+          format: double
+          description: |-
+            Matches any subject where the `age_at_vital_status` field exactly
+            matches the specified value.
+
+            This parameter can either be a JSON number (surrounded by quotes) or
+            `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `age_at_vital_status` are included in the results.
+            - If a number is provided, all entries where `age_at_vital_status`
+            exactly matches the provided number are included in the results.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "age_at_vital_status":
+            365.25 }` to select all subjects with a `age_at_vital_status` of
+            `365.25`.
+          nullable: true
+        deposition:
+          type: string
+          description: |-
+            Matches subjects to their `depositions` value(s) according to the rules
+            laid out below.
+
+            This parameter can either be a JSON string or `null`.
+
+            - If `null` is provided as the value, all entries that are either (a)
+            missing a metadata block or (b) contain a metadata block but are
+            missing a value for `depositions` are included in the results.
+            - If a string is provided, all entries where any `depositions` value
+            exactly matches the provided string are included in the results. Note
+            that this is effectively a logical OR (`||`) across any of the
+            deposition values.
+
+            If the value is not one of the acceptable value types above, an error
+            should be returned indicating this.
+
+            For example, you might provide the filter `{ "deposition":
+            "phs000000.v1.p1" }` to select any subjects where any deposition value
+            matches this string.
+          nullable: true
+        unharmonized:
+          type: object
+          description: |-
+            All unharmonized fields should be filterable as well:
+
+            * Filtering on a singular field should include the `Subject` in the
+            results if the query exactly matches the value of that field for the
+            `Subject` (case-sensitive).
+            * Filtering on field with multiple values should include the `Subject`
+            in the results if the query exactly matches any of the values of the
+            field for that `Subject` (case-sensitive).
+          additionalProperties: {}
+          nullable: true
 tags:
 - name: Subject
   description: Subjects within the CCDI federated ecosystem.


### PR DESCRIPTION
**PR Close Date:** April 30, 2024

This is an experimental extension to https://github.com/CBIIT/ccdi-federation-api/pull/98 whereby filters are implemented as `POST` requests. There is discussion on that thread as to why embedding the JSON values are query parameters may not be desirable (largely to avoid any quirks with major web frameworks handling double quotes correctly). The better way to do this is probably to break filtering out to its own `POST` method and have the JSON request body encode the parameters.

I've sketched the solution here so everyone can weigh the pros and cons of each (and so whichever one we pick can be quickly mergable).

Before submitting this PR, please make sure:

- [ ] You have added a few sentences describing the PR here.
- [ ] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added the relevant groups/individuals to the reviewers.
- [ ] Your commit messages conform to the [Conventional
  Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [ ] You have updated the README or other documentation to account for these
  changes (when appropriate).
- [ ] You have added a line describing the change in the `CHANGELOG.md` under
  `[Unreleased]`.

<!--

If you are adding new metadata elements, please uncomment this section and
complete the checklist as well:

- [ ] I have added my field definition to the appropriate
  `get_field_descriptions()` method. For example, if you add a field to
  subjects, you should include it in the `get_field_descriptions()` method at
  `packages/ccdi_models/src/metadata/field/description/harmonized/subject.rs`.
- [ ] I have confirmed that my field shows up in the relevant
  `/metadata/fields/<entity>` endpoint. For example. if you add a field to
  subjects, it should show up in the fields listed in the output of the
  `/metadata/fields/subject` endpoint.
- [ ] I have confirmed that my field shows up in the relevant wiki generation
  command. For example. if you add a field to subjects, it should show up in the
  `cargo run --release wiki subject` output.

-->
