### PR TITLE
feat: experimental sample-diagnosis endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,23 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Adds an experimental `sample-diagnosis` endpoint with `search` filter to enable case-insensitive substring searching of diagnoses. 
+([discussion](https://github.com/CBIIT/ccdi-federation-api/discussions/131), [#139](https://github.com/CBIIT/ccdi-federation-api/issues/139)).
+
+### Changed
+
+- Updates the sample's diagnosis randomizer ([#139](https://github.com/CBIIT/ccdi-federation-api/issues/139)).
+
 ### Fixed
 
 - Corrects the duplicated `Black or African Amercian` race description
   ([#129](https://github.com/CBIIT/ccdi-federation-api/issues/129)).
 - Updates the depositions field to be nullable
   ([#140](https://github.com/CBIIT/ccdi-federation-api/pull/140)).
+- Adds missing `sample?diagnosis=xyz` search parameter. ([#139](https://github.com/CBIIT/ccdi-federation-api/issues/139)).
+- Adds missing `sample/by/diagnosis/count` endpoint. ([#139](https://github.com/CBIIT/ccdi-federation-api/issues/139)).
 
 ## [v1.1.0] — 12-17-2024
 

--- a/crates/ccdi-models/src/sample/metadata.rs
+++ b/crates/ccdi-models/src/sample/metadata.rs
@@ -726,7 +726,10 @@ impl Metadata {
                 None,
             )]),
             diagnosis: Some(field::unowned::sample::Diagnosis::new(
-                Diagnosis::from(String::from("Random Diagnosis")),
+                Diagnosis::from(format!(
+                    "Random Diagnosis {}",
+                    rng.sample(Alphanumeric).to_ascii_uppercase() as char,
+                )),
                 None,
                 None,
                 None,

--- a/crates/ccdi-openapi/src/api.rs
+++ b/crates/ccdi-openapi/src/api.rs
@@ -85,6 +85,10 @@ use utoipa::openapi;
             name = "Info",
             description = "Information about the API implementation itself."
         ),
+        (
+            name = "Experimental",
+            description = "Endpoints and features in an experimental phase."
+        ),
     ),
     paths(
         // Subject routes.

--- a/crates/ccdi-openapi/src/api.rs
+++ b/crates/ccdi-openapi/src/api.rs
@@ -120,6 +120,9 @@ use utoipa::openapi;
 
         // Information.
         server::routes::info::info_index,
+
+        // Experimental.
+        server::routes::sample_diagnosis::sample_diagnosis_index,
     ),
     components(schemas(
         // Harmonized common metadata elements.

--- a/crates/ccdi-server/src/filter.rs
+++ b/crates/ccdi-server/src/filter.rs
@@ -8,6 +8,7 @@ use models::Entity;
 
 pub mod file;
 pub mod sample;
+pub mod sample_diagnosis;
 pub mod subject;
 
 /// A trait that defines a method for filtering by metadata values.

--- a/crates/ccdi-server/src/filter/sample.rs
+++ b/crates/ccdi-server/src/filter/sample.rs
@@ -24,6 +24,7 @@ impl FilterMetadataField<Sample, FilterSampleParams> for Vec<Sample> {
             "age_at_collection" => params.age_at_collection.as_ref(),
             "tumor_tissue_morphology" => params.tumor_tissue_morphology.as_ref(),
             "depositions" => params.depositions.as_ref(),
+            "diagnosis" => params.diagnosis.as_ref(),
             _ => unreachable!("unhandled sample metadata field: {field}"),
         };
 
@@ -104,6 +105,11 @@ impl FilterMetadataField<Sample, FilterSampleParams> for Vec<Sample> {
                                 })
                                 .collect::<Vec<String>>()
                         }),
+                    "diagnosis" => sample
+                        .metadata()
+                        .and_then(|metadata| metadata.diagnosis())
+                        .map(|diagnosis| vec![diagnosis.to_string()]),
+
                     _ => unreachable!("unhandled sample metadata field: {field}"),
                 };
 

--- a/crates/ccdi-server/src/filter/sample.rs
+++ b/crates/ccdi-server/src/filter/sample.rs
@@ -25,6 +25,7 @@ impl FilterMetadataField<Sample, FilterSampleParams> for Vec<Sample> {
             "tumor_tissue_morphology" => params.tumor_tissue_morphology.as_ref(),
             "depositions" => params.depositions.as_ref(),
             "diagnosis" => params.diagnosis.as_ref(),
+            "search" => params.search.as_ref(),
             _ => unreachable!("unhandled sample metadata field: {field}"),
         };
 
@@ -37,87 +38,116 @@ impl FilterMetadataField<Sample, FilterSampleParams> for Vec<Sample> {
 
         self.into_iter()
             .filter(|sample| {
-                let values: Option<Vec<String>> = match field.as_str() {
-                    "anatomical_sites" => sample
-                        .metadata()
-                        .and_then(|metadata| metadata.anatomical_sites())
-                        .map(|sites| {
-                            sites
-                                .iter()
-                                .map(|site| site.to_string())
-                                .collect::<Vec<_>>()
-                        }),
-                    "disease_phase" => sample
-                        .metadata()
-                        .and_then(|metadata| metadata.disease_phase())
-                        .map(|disease_phase| vec![disease_phase.to_string()]),
-                    "library_selection_method" => sample
-                        .metadata()
-                        .and_then(|metadata| metadata.library_selection_method())
-                        .map(|library_selection_method| vec![library_selection_method.to_string()]),
-                    "library_strategy" => sample
-                        .metadata()
-                        .and_then(|metadata| metadata.library_strategy())
-                        .map(|library_strategy| vec![library_strategy.to_string()]),
-                    "library_source_material" => sample
-                        .metadata()
-                        .and_then(|metadata| metadata.library_source_material())
-                        .map(|library_source_material| vec![library_source_material.to_string()]),
-                    "preservation_method" => sample
-                        .metadata()
-                        .and_then(|metadata| metadata.preservation_method())
-                        .map(|preservation_method| vec![preservation_method.to_string()]),
-                    "specimen_molecular_analyte_type" => sample
-                        .metadata()
-                        .and_then(|metadata| metadata.specimen_molecular_analyte_type())
-                        .map(|specimen_molecular_analyte_type| {
-                            vec![specimen_molecular_analyte_type.to_string()]
-                        }),
-                    "tissue_type" => sample
-                        .metadata()
-                        .and_then(|metadata| metadata.tissue_type())
-                        .map(|tissue_type| vec![tissue_type.to_string()]),
-                    "tumor_classification" => sample
-                        .metadata()
-                        .and_then(|metadata| metadata.tumor_classification())
-                        .map(|tumor_classification| vec![tumor_classification.to_string()]),
-                    "age_at_diagnosis" => sample
-                        .metadata()
-                        .and_then(|metadata| metadata.age_at_diagnosis())
-                        .map(|age_at_diagnosis| vec![age_at_diagnosis.to_string()]),
-                    "age_at_collection" => sample
-                        .metadata()
-                        .and_then(|metadata| metadata.age_at_collection())
-                        .map(|age_at_collection| vec![age_at_collection.to_string()]),
-                    "tumor_tissue_morphology" => sample
-                        .metadata()
-                        .and_then(|metadata| metadata.tumor_tissue_morphology())
-                        .map(|tumor_tissue_morphology| vec![tumor_tissue_morphology.to_string()]),
-                    "depositions" => sample
-                        .metadata()
-                        .and_then(|metadata| metadata.common().depositions())
-                        .map(|deposition| {
-                            deposition
-                                .iter()
-                                .cloned()
-                                .map(|accession| match accession {
-                                    Accession::dbGaP(accession) => accession.to_string(),
-                                })
-                                .collect::<Vec<String>>()
-                        }),
-                    "diagnosis" => sample
-                        .metadata()
-                        .and_then(|metadata| metadata.diagnosis())
-                        .map(|diagnosis| vec![diagnosis.to_string()]),
+                // Search field matches by substring rather than exact match.
+                if field.as_str() == "search" {
+                    if let Some(metadata) = sample.metadata() {
+                        if let Some(diagnosis) = metadata.diagnosis() {
+                            // Only return the entry if the query is a substring
+                            // of the diagnosis, ignoring case.
+                            // Matching on to_lowercase is an approximation and will not cover
+                            // all unicode characters.
+                            let diagnosis_lower = diagnosis.to_string().to_lowercase();
+                            let query_lower = query.to_string().to_lowercase();
+                            return diagnosis_lower.to_string().contains(&query_lower);
+                        }
 
-                    _ => unreachable!("unhandled sample metadata field: {field}"),
-                };
+                        // If the metadata doesn't have a diagnosis, the entry
+                        // should not be included.
+                        return false;
+                    }
 
-                match values {
-                    Some(values) => values.into_iter().any(|s| s.eq(query)),
-                    // Samples with no values for this field are automatically
-                    // filtered as described in the rules for filtering.
-                    None => false,
+                    // If no metadata is included, this entry should not be
+                    // included.
+                    false
+                } else {
+                    // All other "non-search" fields require an exact case-sensitive match.
+                    let values: Option<Vec<String>> = match field.as_str() {
+                        "anatomical_sites" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.anatomical_sites())
+                            .map(|sites| {
+                                sites
+                                    .iter()
+                                    .map(|site| site.to_string())
+                                    .collect::<Vec<_>>()
+                            }),
+                        "disease_phase" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.disease_phase())
+                            .map(|disease_phase| vec![disease_phase.to_string()]),
+                        "library_selection_method" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.library_selection_method())
+                            .map(|library_selection_method| {
+                                vec![library_selection_method.to_string()]
+                            }),
+                        "library_strategy" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.library_strategy())
+                            .map(|library_strategy| vec![library_strategy.to_string()]),
+                        "library_source_material" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.library_source_material())
+                            .map(|library_source_material| {
+                                vec![library_source_material.to_string()]
+                            }),
+                        "preservation_method" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.preservation_method())
+                            .map(|preservation_method| vec![preservation_method.to_string()]),
+                        "specimen_molecular_analyte_type" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.specimen_molecular_analyte_type())
+                            .map(|specimen_molecular_analyte_type| {
+                                vec![specimen_molecular_analyte_type.to_string()]
+                            }),
+                        "tissue_type" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.tissue_type())
+                            .map(|tissue_type| vec![tissue_type.to_string()]),
+                        "tumor_classification" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.tumor_classification())
+                            .map(|tumor_classification| vec![tumor_classification.to_string()]),
+                        "age_at_diagnosis" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.age_at_diagnosis())
+                            .map(|age_at_diagnosis| vec![age_at_diagnosis.to_string()]),
+                        "age_at_collection" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.age_at_collection())
+                            .map(|age_at_collection| vec![age_at_collection.to_string()]),
+                        "tumor_tissue_morphology" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.tumor_tissue_morphology())
+                            .map(|tumor_tissue_morphology| {
+                                vec![tumor_tissue_morphology.to_string()]
+                            }),
+                        "depositions" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.common().depositions())
+                            .map(|deposition| {
+                                deposition
+                                    .iter()
+                                    .cloned()
+                                    .map(|accession| match accession {
+                                        Accession::dbGaP(accession) => accession.to_string(),
+                                    })
+                                    .collect::<Vec<String>>()
+                            }),
+                        "diagnosis" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.diagnosis())
+                            .map(|diagnosis| vec![diagnosis.to_string()]),
+                        _ => unreachable!("unhandled sample metadata field: {field}"),
+                    };
+
+                    match values {
+                        Some(values) => values.into_iter().any(|s| s.eq(query)),
+                        // Samples with no values for this field are automatically
+                        // filtered as described in the rules for filtering.
+                        None => false,
+                    }
                 }
             })
             .collect::<Vec<_>>()

--- a/crates/ccdi-server/src/filter/sample_diagnosis.rs
+++ b/crates/ccdi-server/src/filter/sample_diagnosis.rs
@@ -1,0 +1,159 @@
+//! Filter parameters for [`Sample`]s on the sample-diagnosis endpoint.
+
+use ccdi_models as models;
+
+use models::metadata::common::deposition::Accession;
+use models::Sample;
+
+use crate::filter::FilterMetadataField;
+use crate::params::filter::SampleDiagnosis as FilterSampleDiagnosisParams;
+
+impl FilterMetadataField<Sample, FilterSampleDiagnosisParams> for Vec<Sample> {
+    fn filter_metadata_field(
+        self,
+        field: String,
+        params: &FilterSampleDiagnosisParams,
+    ) -> Vec<Sample> {
+        let parameter = match field.as_str() {
+            "anatomical_sites" => params.anatomical_sites.as_ref(),
+            "disease_phase" => params.disease_phase.as_ref(),
+            "library_selection_method" => params.library_selection_method.as_ref(),
+            "library_strategy" => params.library_strategy.as_ref(),
+            "library_source_material" => params.library_source_material.as_ref(),
+            "preservation_method" => params.preservation_method.as_ref(),
+            "specimen_molecular_analyte_type" => params.specimen_molecular_analyte_type.as_ref(),
+            "tissue_type" => params.tissue_type.as_ref(),
+            "tumor_classification" => params.tumor_classification.as_ref(),
+            "age_at_diagnosis" => params.age_at_diagnosis.as_ref(),
+            "age_at_collection" => params.age_at_collection.as_ref(),
+            "tumor_tissue_morphology" => params.tumor_tissue_morphology.as_ref(),
+            "depositions" => params.depositions.as_ref(),
+            "diagnosis" => params.diagnosis.as_ref(),
+            "search" => params.search.as_ref(),
+            _ => unreachable!("unhandled sample metadata field: {field}"),
+        };
+
+        let query = match parameter {
+            Some(query) => query,
+            // If the parameter has no value, just return the original list of
+            // samples, as the user does not want to filter based on that.
+            None => return self,
+        };
+
+        self.into_iter()
+            .filter(|sample| {
+                // Search field matches by substring rather than exact match.
+                if field.as_str() == "search" {
+                    if let Some(metadata) = sample.metadata() {
+                        if let Some(diagnosis) = metadata.diagnosis() {
+                            // Only return the entry if the query is a substring
+                            // of the diagnosis, ignoring case.
+                            // Matching on to_lowercase is an approximation and will not cover
+                            // all unicode characters.
+                            let diagnosis_lower = diagnosis.to_string().to_lowercase();
+                            let query_lower = query.to_string().to_lowercase();
+                            return diagnosis_lower.to_string().contains(&query_lower);
+                        }
+
+                        // If the metadata doesn't have a diagnosis, the entry
+                        // should not be included.
+                        return false;
+                    }
+
+                    // If no metadata is included, this entry should not be
+                    // included.
+                    false
+                } else {
+                    // All other "non-search" fields require an exact case-sensitive match.
+                    let values: Option<Vec<String>> = match field.as_str() {
+                        "anatomical_sites" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.anatomical_sites())
+                            .map(|sites| {
+                                sites
+                                    .iter()
+                                    .map(|site| site.to_string())
+                                    .collect::<Vec<_>>()
+                            }),
+                        "disease_phase" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.disease_phase())
+                            .map(|disease_phase| vec![disease_phase.to_string()]),
+                        "library_selection_method" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.library_selection_method())
+                            .map(|library_selection_method| {
+                                vec![library_selection_method.to_string()]
+                            }),
+                        "library_strategy" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.library_strategy())
+                            .map(|library_strategy| vec![library_strategy.to_string()]),
+                        "library_source_material" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.library_source_material())
+                            .map(|library_source_material| {
+                                vec![library_source_material.to_string()]
+                            }),
+                        "preservation_method" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.preservation_method())
+                            .map(|preservation_method| vec![preservation_method.to_string()]),
+                        "specimen_molecular_analyte_type" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.specimen_molecular_analyte_type())
+                            .map(|specimen_molecular_analyte_type| {
+                                vec![specimen_molecular_analyte_type.to_string()]
+                            }),
+                        "tissue_type" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.tissue_type())
+                            .map(|tissue_type| vec![tissue_type.to_string()]),
+                        "tumor_classification" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.tumor_classification())
+                            .map(|tumor_classification| vec![tumor_classification.to_string()]),
+                        "age_at_diagnosis" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.age_at_diagnosis())
+                            .map(|age_at_diagnosis| vec![age_at_diagnosis.to_string()]),
+                        "age_at_collection" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.age_at_collection())
+                            .map(|age_at_collection| vec![age_at_collection.to_string()]),
+                        "tumor_tissue_morphology" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.tumor_tissue_morphology())
+                            .map(|tumor_tissue_morphology| {
+                                vec![tumor_tissue_morphology.to_string()]
+                            }),
+                        "depositions" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.common().depositions())
+                            .map(|deposition| {
+                                deposition
+                                    .iter()
+                                    .cloned()
+                                    .map(|accession| match accession {
+                                        Accession::dbGaP(accession) => accession.to_string(),
+                                    })
+                                    .collect::<Vec<String>>()
+                            }),
+                        "diagnosis" => sample
+                            .metadata()
+                            .and_then(|metadata| metadata.diagnosis())
+                            .map(|diagnosis| vec![diagnosis.to_string()]),
+                        _ => unreachable!("unhandled sample metadata field: {field}"),
+                    };
+
+                    match values {
+                        Some(values) => values.into_iter().any(|s| s.eq(query)),
+                        // Samples with no values for this field are automatically
+                        // filtered as described in the rules for filtering.
+                        None => false,
+                    }
+                }
+            })
+            .collect::<Vec<_>>()
+    }
+}

--- a/crates/ccdi-server/src/params/filter.rs
+++ b/crates/ccdi-server/src/params/filter.rs
@@ -75,8 +75,6 @@ pub struct Subject {
 /// matches the value provided for the parameter (i.e., matching is done by
 /// looking for the provided parameter as a substring). Matches are
 /// case-sensitive.
-/// For the "search" parameter only, matching is case-insensitive and requires
-/// only a substring match rather than an exact match.
 #[derive(Debug, Default, Deserialize, IntoParams, Introspect, Serialize)]
 #[into_params(parameter_in = Query)]
 pub struct Sample {
@@ -169,12 +167,116 @@ pub struct Sample {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[param(required = false, nullable = false)]
     pub diagnosis: Option<String>,
+}
 
+/// Parameters for filtering experimental sample-diagnosis endpoint.
+///
+/// None of the parameters are required, but they may be provided as a
+/// [`String`]. When a parameter is provided, the endpoint will filter the
+/// results to only include [`Sample`]s where the value for the key exactly
+/// matches the value provided for the parameter (i.e., matching is done by
+/// looking for the provided parameter as a substring). Matches are
+/// case-sensitive.
+/// For the "search" parameter only, matching is case-insensitive and requires
+/// only a substring match rather than an exact match.
+#[derive(Debug, Default, Deserialize, IntoParams, Introspect, Serialize)]
+#[into_params(parameter_in = Query)]
+pub struct SampleDiagnosis {
     /// Matches any sample where the `diagnosis` field contains the
     /// string provided, ignoring case.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[param(required = false, nullable = false)]
     pub search: Option<String>,
+
+    /// Matches any sample where the `disease_phase` field matches the string
+    /// provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub disease_phase: Option<String>,
+
+    /// Matches any sample where the `anatomical_sites` field matches the string
+    /// provided.
+    ///
+    /// **Note:** a logical OR (`||`) is performed across the values when
+    /// determining whether the subject should be included in the results.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub anatomical_sites: Option<String>,
+
+    /// Matches any sample where the `library_selection_method` field matches the string
+    /// provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub library_selection_method: Option<String>,
+
+    /// Matches any sample where the `library_strategy` field matches the string
+    /// provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub library_strategy: Option<String>,
+
+    /// Matches any sample where the `library_source_material` field matches the string
+    /// provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub library_source_material: Option<String>,
+
+    /// Matches any sample where the `preservation_method` field matches the string
+    /// provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub preservation_method: Option<String>,
+
+    /// Matches any sample where the `specimen_molecular_analyte_type` field matches the string
+    /// provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub specimen_molecular_analyte_type: Option<String>,
+
+    /// Matches any sample where the `tissue_type` field matches the string
+    /// provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub tissue_type: Option<String>,
+
+    /// Matches any sample where the `tumor_classification` field matches the
+    /// string provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub tumor_classification: Option<String>,
+
+    /// Matches any sample where the `age_at_diagnosis` field matches the string
+    /// provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub age_at_diagnosis: Option<String>,
+
+    /// Matches any sample where the `age_at_collection` field matches the
+    /// string provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub age_at_collection: Option<String>,
+
+    /// Matches any sample where the `tumor_tissue_morphology` field matches the
+    /// string provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub tumor_tissue_morphology: Option<String>,
+
+    /// Matches any sample where any member of the `depositions` fields match
+    /// the string provided.
+    ///
+    /// **Note:** a logical OR (`||`) is performed across the values when
+    /// determining whether the sample should be included in the results.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub depositions: Option<String>,
+
+    /// Matches any sample where the `diagnosis` field matches the
+    /// string provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub diagnosis: Option<String>,
 }
 
 /// Parameters for filtering files.

--- a/crates/ccdi-server/src/params/filter.rs
+++ b/crates/ccdi-server/src/params/filter.rs
@@ -161,6 +161,12 @@ pub struct Sample {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[param(required = false, nullable = false)]
     pub depositions: Option<String>,
+
+    /// Matches any sample where the `diagnosis` field matches the
+    /// string provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub diagnosis: Option<String>,
 }
 
 /// Parameters for filtering files.

--- a/crates/ccdi-server/src/params/filter.rs
+++ b/crates/ccdi-server/src/params/filter.rs
@@ -75,6 +75,8 @@ pub struct Subject {
 /// matches the value provided for the parameter (i.e., matching is done by
 /// looking for the provided parameter as a substring). Matches are
 /// case-sensitive.
+/// For the "search" parameter only, matching is case-insensitive and requires
+/// only a substring match rather than an exact match.
 #[derive(Debug, Default, Deserialize, IntoParams, Introspect, Serialize)]
 #[into_params(parameter_in = Query)]
 pub struct Sample {
@@ -167,6 +169,12 @@ pub struct Sample {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[param(required = false, nullable = false)]
     pub diagnosis: Option<String>,
+
+    /// Matches any sample where the `diagnosis` field contains the
+    /// string provided, ignoring case.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub search: Option<String>,
 }
 
 /// Parameters for filtering files.

--- a/crates/ccdi-server/src/routes.rs
+++ b/crates/ccdi-server/src/routes.rs
@@ -6,6 +6,7 @@ pub mod metadata;
 pub mod namespace;
 pub mod organization;
 pub mod sample;
+pub mod sample_diagnosis;
 pub mod subject;
 
 /// A result for a group by operation.

--- a/crates/ccdi-server/src/routes/sample.rs
+++ b/crates/ccdi-server/src/routes/sample.rs
@@ -418,7 +418,7 @@ fn parse_field(field: &str, sample: &Sample) -> Option<Option<Value>> {
             ),
             None => Some(None),
         },
-        "diagnosis" => match sample.metadata(){
+        "diagnosis" => match sample.metadata() {
             Some(metadata) => Some(
                 metadata
                     .diagnosis()

--- a/crates/ccdi-server/src/routes/sample.rs
+++ b/crates/ccdi-server/src/routes/sample.rs
@@ -418,6 +418,18 @@ fn parse_field(field: &str, sample: &Sample) -> Option<Option<Value>> {
             ),
             None => Some(None),
         },
+        "diagnosis" => match sample.metadata(){
+            Some(metadata) => Some(
+                metadata
+                    .diagnosis()
+                    .as_ref()
+                    // SAFETY: all metadata fields are able to be represented as
+                    // [`serde_json::Value`]s.
+                    .map(|diagnosis| serde_json::to_value(diagnosis.value()).unwrap())
+                    .or(Some(Value::Null)),
+            ),
+            None => Some(None),
+        },
         "disease_phase" => match sample.metadata() {
             Some(metadata) => Some(
                 metadata

--- a/crates/ccdi-server/src/routes/sample.rs
+++ b/crates/ccdi-server/src/routes/sample.rs
@@ -83,7 +83,8 @@ pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
             .service(sample_index)
             .service(samples_by_count)
             .service(sample_show)
-            .service(sample_summary);
+            .service(sample_summary)
+            .service(sample_diagnosis);
     }
 }
 
@@ -579,6 +580,36 @@ fn parse_field(field: &str, sample: &Sample) -> Option<Option<Value>> {
 pub async fn sample_summary(samples: Data<Store>) -> impl Responder {
     let samples = samples.samples.lock().unwrap().clone();
     HttpResponse::Ok().json(Summary::new(samples.len()))
+}
+
+/// Gets the samples known by this server via free-text diagnosis search.
+#[utoipa::path(
+    get,
+    path = "/sample-diagnosis",
+    tag = "Sample-Diagnosis",
+    responses(
+        (status = 200, description = "Successful operation.", body = responses::Summary),
+    )
+)]
+#[get("/sample-diagnosis")]
+pub async fn sample_diagnosis(
+    filter_params: Query<FilterSampleParams>,
+    pagination_params: Query<PaginationParams>,
+    samples: Data<Store>,
+) -> impl Responder {
+    let mut samples = samples.samples.lock().unwrap().clone();
+
+    // See the note in the documentation for this endpoint: the results must be
+    // sorted by identifier by default.
+    samples.sort();
+
+    let samples = filter::<Sample, FilterSampleParams>(samples, filter_params.0);
+
+    paginate::response::<Sample, Samples>(
+        pagination_params.0,
+        samples,
+        "http://localhost:8000/sample-diagnosis",
+    )
 }
 
 #[cfg(test)]

--- a/crates/ccdi-server/src/routes/sample.rs
+++ b/crates/ccdi-server/src/routes/sample.rs
@@ -83,8 +83,7 @@ pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
             .service(sample_index)
             .service(samples_by_count)
             .service(sample_show)
-            .service(sample_summary)
-            .service(sample_diagnosis);
+            .service(sample_summary);
     }
 }
 
@@ -580,36 +579,6 @@ fn parse_field(field: &str, sample: &Sample) -> Option<Option<Value>> {
 pub async fn sample_summary(samples: Data<Store>) -> impl Responder {
     let samples = samples.samples.lock().unwrap().clone();
     HttpResponse::Ok().json(Summary::new(samples.len()))
-}
-
-/// Gets the samples known by this server via free-text diagnosis search.
-#[utoipa::path(
-    get,
-    path = "/sample-diagnosis",
-    tag = "Sample-Diagnosis",
-    responses(
-        (status = 200, description = "Successful operation.", body = responses::Summary),
-    )
-)]
-#[get("/sample-diagnosis")]
-pub async fn sample_diagnosis(
-    filter_params: Query<FilterSampleParams>,
-    pagination_params: Query<PaginationParams>,
-    samples: Data<Store>,
-) -> impl Responder {
-    let mut samples = samples.samples.lock().unwrap().clone();
-
-    // See the note in the documentation for this endpoint: the results must be
-    // sorted by identifier by default.
-    samples.sort();
-
-    let samples = filter::<Sample, FilterSampleParams>(samples, filter_params.0);
-
-    paginate::response::<Sample, Samples>(
-        pagination_params.0,
-        samples,
-        "http://localhost:8000/sample-diagnosis",
-    )
 }
 
 #[cfg(test)]

--- a/crates/ccdi-server/src/routes/sample_diagnosis.rs
+++ b/crates/ccdi-server/src/routes/sample_diagnosis.rs
@@ -1,0 +1,194 @@
+//! Routes related to the experimental sample-diagnosis endpoint.
+
+use actix_web::get;
+use actix_web::web::Data;
+use actix_web::web::Query;
+use actix_web::web::ServiceConfig;
+use actix_web::Responder;
+
+use ccdi_models as models;
+
+use models::Sample;
+
+use crate::filter::filter;
+use crate::paginate;
+use crate::params::filter::SampleDiagnosis as FilterSampleDiagnosisParams;
+use crate::params::PaginationParams;
+use crate::responses::error;
+use crate::responses::Errors;
+use crate::responses::Samples;
+
+use crate::routes::sample::Store;
+
+/// Configures the [`ServiceConfig`] with the sample-diagnosis paths.
+/// This uses the existing data store made by the samples object.
+pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
+    |config: &mut ServiceConfig| {
+        config.app_data(store).service(sample_diagnosis_index);
+    }
+}
+
+/// Experimental: Filter the samples known by this server by free-text diagnosis search.
+///
+/// ### Diagnosis Filtering
+///
+/// This endpoint supports the experimental `search` parameter.
+/// For this parameter, the sample is included in the results if the value of its
+/// its `diagnosis` field _contains_ the query string, or if an unharmonized field
+/// treated by the implementer as a diagnosis field contains that query string.
+/// Matches are case-insensitive.
+///
+/// ### Pagination
+///
+/// This endpoint is paginated. Users may override the default pagination
+/// parameters by providing one or more of the pagination-related query
+/// parameters below.
+///
+/// ### Additional Filtering
+///
+/// All harmonized (top-level) and unharmonized (nested under the
+/// `metadata.unharmonized` key) metadata fields are filterable. To achieve
+/// this, you can provide the field name as a [`String`]. Filtering follows the
+/// following rules:
+///
+/// * For single-value metadata field, the sample is included in the results if
+///   its value _exactly_ matches the query string. Matches are case-sensitive.
+/// * For multiple-value metadata fields, the sample is included in the results
+///   if any of its values for the field _exactly_ match the query string (a
+///   logical OR [`||`]). Matches are case-sensitive.
+/// * When the metadata field is `null` (in the case of singular or
+///   multiple-valued metadata fields) or empty, the sample is not included.
+/// * When multiple fields are provided as filters, a logical AND (`&&`) strings
+///   together the predicates. In other words, all filters must match for a
+///   sample to be returned. Note that this means that servers do not natively
+///   support logical OR (`||`) across multiple fields: that must be done by
+///   calling this endpoint with each of your desired queries and performing a
+///   set union of those samples out of band.
+///
+/// ### Ordering
+///
+/// This endpoint has default ordering requirements—those details are documented
+/// in the `responses::Samples` schema.
+#[utoipa::path(
+    get,
+    path = "/sample-diagnosis",
+    tag = "Experimental",
+    params(
+        FilterSampleDiagnosisParams,
+        (
+            "metadata.unharmonized.<field>" = Option<String>,
+            Query,
+            nullable = false,
+            description = "All unharmonized fields should be filterable in the \
+            same manner as harmonized fields:\n\n\
+            * Filtering on a singular field should include the `Sample` in \
+            the results if the query exactly matches the value of that field \
+            for the `Sample` (case-sensitive).\n\
+            * Filtering on field with multiple values should include the \
+            `Sample` in the results if the query exactly matches any of the \
+            values of the field for that `Sample` (case-sensitive).\n\
+            * Unlike harmonized fields, unharmonized fields must be prefixed \
+            with `metadata.unharmonized`.\n\n\
+            **Note:** this query parameter is intended to be symbolic of any \
+            unharmonized field. Because of limitations within Swagger UI, it \
+            will show up as a query parameter that can be optionally be \
+            submitted as part of a request within Swagger UI. Please keep in \
+            mind that the literal query parameter \
+            `?metadata.unharmonized.<field>=value` is not supported, so \
+            attempting to use it within Swagger UI will not work!"
+        ),
+        PaginationParams,
+    ),
+    responses(
+        (
+            status = 200,
+            description = "Successful operation.",
+            body = responses::Samples,
+            headers(
+                (
+                    "link" = String,
+                    description = "Links to URLs that may be of interest \
+                    when paging through paginated responses. This header \
+                    contains two or more links of interest. The format of the \
+                    field is as follows: \
+                    \n\
+                    \n`Link: <URL>; rel=\"REL\"` \
+                    \n\
+                    ### Relationships\n\n\
+                    In the format above, `URL` represents a valid URL for \
+                    the link of interest and `REL` is one of four values: \n\
+                    - `first` (_Required_). A link to the first page in the \
+                    results (can be the same as `last` if there is only one \
+                    page).\n\
+                    - `last` (_Required_). A link to the first page in the \
+                    results (can be the same as `first` if there is only one \
+                    page).\n\
+                    - `next` (_Optional_). A link to the next page (if it \
+                    exists).\n\
+                    - `prev` (_Optional_). A link to the previous page (if it \
+                    exists).\n\n\
+                    ### Requirements\n\n\
+                    - This header _must_ provide links for at least the `first` \
+                    and `last` rels.\n \
+                    - The `prev` and `next` links must exist only (a) when there \
+                    are multiple pages in the result page set and (b) when the \
+                    current page is not the first or last page, respectively.\n\
+                    - This list of links is unordered.\n\n \
+                    ### Notes\n\n\
+                    - HTTP 1.1 and HTTP 2.0 dictate that response \
+                    headers are case insensitive. Though not required, we \
+                    recommend an all lowercase name of `link` for this \
+                    response header."
+                )
+            )
+        ),
+        (
+            status = 404,
+            description = "Not found.\nServers that cannot provide line-level \
+            data should use this response rather than Forbidden (403), as \
+            there is no level of authorization that would allow one to access \
+            the information included in the API.",
+            body = responses::Errors,
+            example = json!(
+                Errors::from(
+                    error::Kind::unshareable_data(
+                        String::from("samples"),
+                        String::from(
+                            "Our agreement with data providers prohibits us from sharing \
+                            line-level data."
+                        ),
+                    )
+                )
+            )
+        ),
+        (
+            status = 422,
+            description = "Invalid query or path parameters.",
+            body = responses::Errors,
+            example = json!(Errors::from(error::Kind::invalid_parameters(
+                Some(vec![String::from("page"), String::from("per_page")]),
+                String::from("unable to calculate offset")
+            )))
+        ),
+    )
+)]
+#[get("/sample-diagnosis")]
+pub async fn sample_diagnosis_index(
+    filter_params: Query<FilterSampleDiagnosisParams>,
+    pagination_params: Query<PaginationParams>,
+    samples: Data<Store>,
+) -> impl Responder {
+    let mut samples = samples.samples.lock().unwrap().clone();
+
+    // See the note in the documentation for this endpoint: the results must be
+    // sorted by identifier by default.
+    samples.sort();
+
+    let samples = filter::<Sample, FilterSampleDiagnosisParams>(samples, filter_params.0);
+
+    paginate::response::<Sample, Samples>(
+        pagination_params.0,
+        samples,
+        "http://localhost:8000/sample-diagnosis",
+    )
+}

--- a/crates/ccdi-spec/src/main.rs
+++ b/crates/ccdi-spec/src/main.rs
@@ -40,6 +40,7 @@ use server::routes::info;
 use server::routes::metadata;
 use server::routes::namespace;
 use server::routes::sample;
+use server::routes::sample_diagnosis;
 use server::routes::subject;
 
 mod utils;
@@ -339,6 +340,7 @@ fn inner() -> Result<(), Box<dyn std::error::Error>> {
                         .configure(namespace::configure())
                         .configure(organization::configure())
                         .configure(info::configure())
+                        .configure(sample_diagnosis::configure(samples.clone()))
                         .service(
                             SwaggerUi::new("/swagger-ui/{_:.*}")
                                 .url("/api-docs/openapi.json", Api::openapi()),

--- a/swagger.yml
+++ b/swagger.yml
@@ -462,6 +462,14 @@ paths:
         required: false
         schema:
           type: string
+      - name: search
+        in: query
+        description: |-
+          Matches any sample where the `diagnosis` field contains the
+          string provided, ignoring case.
+        required: false
+        schema:
+          type: string
       - name: metadata.unharmonized.<field>
         in: query
         description: |-

--- a/swagger.yml
+++ b/swagger.yml
@@ -454,6 +454,14 @@ paths:
         required: false
         schema:
           type: string
+      - name: diagnosis
+        in: query
+        description: |-
+          Matches any sample where the `diagnosis` field matches the
+          string provided.
+        required: false
+        schema:
+          type: string
       - name: metadata.unharmonized.<field>
         in: query
         description: |-

--- a/swagger.yml
+++ b/swagger.yml
@@ -462,14 +462,6 @@ paths:
         required: false
         schema:
           type: string
-      - name: search
-        in: query
-        description: |-
-          Matches any sample where the `diagnosis` field contains the
-          string provided, ignoring case.
-        required: false
-        schema:
-          type: string
       - name: metadata.unharmonized.<field>
         in: query
         description: |-
@@ -1050,6 +1042,258 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/responses.Information'
+  /sample-diagnosis:
+    get:
+      tags:
+      - Experimental
+      summary: 'Experimental: Filter the samples known by this server by free-text diagnosis search.'
+      description: |-
+        Experimental: Filter the samples known by this server by free-text diagnosis search.
+
+        ### Diagnosis Filtering
+
+        This endpoint supports the experimental `search` parameter.
+        For this parameter, the sample is included in the results if the value of its
+        its `diagnosis` field _contains_ the query string, or if an unharmonized field
+        treated by the implementer as a diagnosis field contains that query string.
+        Matches are case-insensitive.
+
+        ### Pagination
+
+        This endpoint is paginated. Users may override the default pagination
+        parameters by providing one or more of the pagination-related query
+        parameters below.
+
+        ### Additional Filtering
+
+        All harmonized (top-level) and unharmonized (nested under the
+        `metadata.unharmonized` key) metadata fields are filterable. To achieve
+        this, you can provide the field name as a [`String`]. Filtering follows the
+        following rules:
+
+        * For single-value metadata field, the sample is included in the results if
+        its value _exactly_ matches the query string. Matches are case-sensitive.
+        * For multiple-value metadata fields, the sample is included in the results
+        if any of its values for the field _exactly_ match the query string (a
+        logical OR [`||`]). Matches are case-sensitive.
+        * When the metadata field is `null` (in the case of singular or
+        multiple-valued metadata fields) or empty, the sample is not included.
+        * When multiple fields are provided as filters, a logical AND (`&&`) strings
+        together the predicates. In other words, all filters must match for a
+        sample to be returned. Note that this means that servers do not natively
+        support logical OR (`||`) across multiple fields: that must be done by
+        calling this endpoint with each of your desired queries and performing a
+        set union of those samples out of band.
+
+        ### Ordering
+
+        This endpoint has default ordering requirements—those details are documented
+        in the `responses::Samples` schema.
+      operationId: sample_diagnosis_index
+      parameters:
+      - name: search
+        in: query
+        description: |-
+          Matches any sample where the `diagnosis` field contains the
+          string provided, ignoring case.
+        required: false
+        schema:
+          type: string
+      - name: disease_phase
+        in: query
+        description: |-
+          Matches any sample where the `disease_phase` field matches the string
+          provided.
+        required: false
+        schema:
+          type: string
+      - name: anatomical_sites
+        in: query
+        description: |-
+          Matches any sample where the `anatomical_sites` field matches the string
+          provided.
+
+          **Note:** a logical OR (`||`) is performed across the values when
+          determining whether the subject should be included in the results.
+        required: false
+        schema:
+          type: string
+      - name: library_selection_method
+        in: query
+        description: |-
+          Matches any sample where the `library_selection_method` field matches the string
+          provided.
+        required: false
+        schema:
+          type: string
+      - name: library_strategy
+        in: query
+        description: |-
+          Matches any sample where the `library_strategy` field matches the string
+          provided.
+        required: false
+        schema:
+          type: string
+      - name: library_source_material
+        in: query
+        description: |-
+          Matches any sample where the `library_source_material` field matches the string
+          provided.
+        required: false
+        schema:
+          type: string
+      - name: preservation_method
+        in: query
+        description: |-
+          Matches any sample where the `preservation_method` field matches the string
+          provided.
+        required: false
+        schema:
+          type: string
+      - name: specimen_molecular_analyte_type
+        in: query
+        description: |-
+          Matches any sample where the `specimen_molecular_analyte_type` field matches the string
+          provided.
+        required: false
+        schema:
+          type: string
+      - name: tissue_type
+        in: query
+        description: |-
+          Matches any sample where the `tissue_type` field matches the string
+          provided.
+        required: false
+        schema:
+          type: string
+      - name: tumor_classification
+        in: query
+        description: |-
+          Matches any sample where the `tumor_classification` field matches the
+          string provided.
+        required: false
+        schema:
+          type: string
+      - name: age_at_diagnosis
+        in: query
+        description: |-
+          Matches any sample where the `age_at_diagnosis` field matches the string
+          provided.
+        required: false
+        schema:
+          type: string
+      - name: age_at_collection
+        in: query
+        description: |-
+          Matches any sample where the `age_at_collection` field matches the
+          string provided.
+        required: false
+        schema:
+          type: string
+      - name: tumor_tissue_morphology
+        in: query
+        description: |-
+          Matches any sample where the `tumor_tissue_morphology` field matches the
+          string provided.
+        required: false
+        schema:
+          type: string
+      - name: depositions
+        in: query
+        description: |-
+          Matches any sample where any member of the `depositions` fields match
+          the string provided.
+
+          **Note:** a logical OR (`||`) is performed across the values when
+          determining whether the sample should be included in the results.
+        required: false
+        schema:
+          type: string
+      - name: diagnosis
+        in: query
+        description: |-
+          Matches any sample where the `diagnosis` field matches the
+          string provided.
+        required: false
+        schema:
+          type: string
+      - name: metadata.unharmonized.<field>
+        in: query
+        description: |-
+          All unharmonized fields should be filterable in the same manner as harmonized fields:
+
+          * Filtering on a singular field should include the `Sample` in the results if the query exactly matches the value of that field for the `Sample` (case-sensitive).
+          * Filtering on field with multiple values should include the `Sample` in the results if the query exactly matches any of the values of the field for that `Sample` (case-sensitive).
+          * Unlike harmonized fields, unharmonized fields must be prefixed with `metadata.unharmonized`.
+
+          **Note:** this query parameter is intended to be symbolic of any unharmonized field. Because of limitations within Swagger UI, it will show up as a query parameter that can be optionally be submitted as part of a request within Swagger UI. Please keep in mind that the literal query parameter `?metadata.unharmonized.<field>=value` is not supported, so attempting to use it within Swagger UI will not work!
+        required: false
+        schema:
+          type: string
+      - name: page
+        in: query
+        description: |-
+          The page to retrieve.
+
+          This is a 1-based index of a page within a page set. The value of `page`
+          **must** default to `1` when this parameter is not provided.
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+      - name: per_page
+        in: query
+        description: |-
+          The number of results per page.
+
+          Each server can select its own default value for `per_page` when this
+          parameter is not provided. That said, the convention within the
+          community is to use `100` as a default value if any value is equally
+          reasonable.
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+      responses:
+        '200':
+          description: Successful operation.
+          headers:
+            link:
+              schema:
+                type: string
+              description: "Links to URLs that may be of interest when paging through paginated responses. This header contains two or more links of interest. The format of the field is as follows: \n\n`Link: <URL>; rel=\"REL\"` \n### Relationships\n\nIn the format above, `URL` represents a valid URL for the link of interest and `REL` is one of four values: \n- `first` (_Required_). A link to the first page in the results (can be the same as `last` if there is only one page).\n- `last` (_Required_). A link to the first page in the results (can be the same as `first` if there is only one page).\n- `next` (_Optional_). A link to the next page (if it exists).\n- `prev` (_Optional_). A link to the previous page (if it exists).\n\n### Requirements\n\n- This header _must_ provide links for at least the `first` and `last` rels.\n - The `prev` and `next` links must exist only (a) when there are multiple pages in the result page set and (b) when the current page is not the first or last page, respectively.\n- This list of links is unordered.\n\n ### Notes\n\n- HTTP 1.1 and HTTP 2.0 dictate that response headers are case insensitive. Though not required, we recommend an all lowercase name of `link` for this response header."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responses.Samples'
+        '404':
+          description: |-
+            Not found.
+            Servers that cannot provide line-level data should use this response rather than Forbidden (403), as there is no level of authorization that would allow one to access the information included in the API.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responses.Errors'
+              example:
+                errors:
+                - kind: UnshareableData
+                  entity: Samples
+                  reason: Our agreement with data providers prohibits us from sharing line-level data.
+                  message: 'Unable to share data for samples: our agreement with data providers prohibits us from sharing line-level data.'
+        '422':
+          description: Invalid query or path parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responses.Errors'
+              example:
+                errors:
+                - kind: InvalidParameters
+                  parameters:
+                  - page
+                  - per_page
+                  reason: Unable to calculate offset.
+                  message: 'Invalid value for parameters ''page'' and ''per_page'': unable to calculate offset.'
 components:
   schemas:
     cde.v1.deposition.DbgapPhsAccession:

--- a/swagger.yml
+++ b/swagger.yml
@@ -19029,6 +19029,8 @@ tags:
   description: List and describe organizations known by this server.
 - name: Info
   description: Information about the API implementation itself.
+- name: Experimental
+  description: Endpoints and features in an experimental phase.
 externalDocs:
   url: https://www.cancer.gov/research/areas/childhood/childhood-cancer-data-initiative
   description: Learn more about the Childhood Cancer Data Initiative


### PR DESCRIPTION
Discussion: https://github.com/CBIIT/ccdi-federation-api/discussions/131 **Improved disease querying**
Projects:
https://github.com/orgs/CBIIT/projects/19/views/1?pane=issue&itemId=102925127
https://github.com/orgs/CBIIT/projects/19/views/1?pane=issue&itemId=102925260

**PR Close Date:** Not yet determined

**Main feature**
Adds `sample-diagnosis` endpoint with a `search` parameter. This parameter performs case-insensitive string subset searching on the `diagnosis` field. 
Examples:
[http://localhost:8000/sample-diagnosis?search=Random Diagnosis](http://localhost:8000/sample-diagnosis?search=Random%20Diagnosis) : Returns all samples with a diagnosis.
http://localhost:8000/sample-diagnosis?search=X : Returns all samples with diagnosis `Random Diagnosis X`
[http://localhost:8000/sample-diagnosis?search=SIS y](http://localhost:8000/sample-diagnosis?search=SIS%20y) Returns all samples with diagnosis `Random Diagnosis Y`

Other `sample` parameters are also usable with `sample-diagnosis`. 
Example: http://localhost:8000/sample-diagnosis?tissue_type=Tumor&per_page=2

**Other changes**
To support the main feature, this pull also implements the following:
- Adds missing `sample?diagnosis=xyz` search parameter. Previously, searching by diagnosis would return all samples
regardless of query value. Example: http://localhost:8000/sample?diagnosis=Random%20Diagnosis%20A
- Updates the sample's diagnosis randomizer. Previously every sample had the same disease, "Random Diagnosis";
now it is "Random Diagnosis X" where X is a letter or digit. This enables diagnosis searching to return meaningful results.
- Adds missing `sample/by/diagnosis/count` endpoint. Example: http://localhost:8000/sample/by/diagnosis/count

**Known Caveats**
- `sample-diagnosis` does not yet appear in the swagger.yml file
- the `search` parameter is not limited to the diagnosis character set described in #131 and will allow searches on all sorts of characters rather than returning an error. Example: [http://localhost:8000/sample-diagnosis?search=/Example🙂%^](http://localhost:8000/sample-diagnosis?search=/Example%F0%9F%99%82%^)
- This implementation also adds the `search` parameter to the `sample` endpoint itself, but testers can choose not to use it.
 
Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [X] You have added the relevant groups/individuals to the reviewers.
- [ ] Your commit messages conform to the [Conventional
      Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard. *(I missed one!)*
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate). *(Not applicable for this change)*
- [x] You have added a line describing the change in the `CHANGELOG.md` under
      `[Unreleased]`.

