### PR TITLE
fix: make depositions field nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Corrects the duplicated `Black or African Amercian` race description
   ([#129](https://github.com/CBIIT/ccdi-federation-api/issues/129)).
+- Updates the depositions field to be nullable
+  ([#140](https://github.com/CBIIT/ccdi-federation-api/pull/140)).
 
 ## [v1.1.0] — 12-17-2024
 

--- a/crates/ccdi-models/src/metadata/common/metadata.rs
+++ b/crates/ccdi-models/src/metadata/common/metadata.rs
@@ -21,7 +21,7 @@ pub struct Metadata {
     /// repository such as dbGaP or EGA, you should also include a gateway and
     /// link pointing to where that entity can be found in the public
     /// repository.
-    #[schema(value_type = Vec<models::metadata::common::deposition::Accession>)]
+    #[schema(value_type = Vec<models::metadata::common::deposition::Accession>, nullable = true)]
     depositions: Option<NonEmpty<Accession>>,
     // NOTE: ensure that any new items added to this struct are also checked in
     // the `is_empty()` method.

--- a/swagger.yml
+++ b/swagger.yml
@@ -3008,6 +3008,7 @@ components:
             repository such as dbGaP or EGA, you should also include a gateway and
             link pointing to where that entity can be found in the public
             repository.
+          nullable: true
     models.metadata.common.deposition.Accession:
       oneOf:
       - type: object


### PR DESCRIPTION
**PR Close Date:** April 4th, 2025

This PR makes the depositions metadata field nullable as the field is not provided by all the federation nodes.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional
      Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added a line describing the change in the `CHANGELOG.md` under
      `[Unreleased]`.

<!--

If you are adding new metadata elements, please uncomment this section and
complete the checklist as well:

- [ ] I have added my field definition to the appropriate
  `get_field_descriptions()` method. For example, if you add a field to
  subjects, you should include it in the `get_field_descriptions()` method at
  `crates/ccdi_models/src/metadata/field/description/harmonized/subject.rs`.
- [ ] I have confirmed that my field shows up in the relevant
  `/metadata/fields/<entity>` endpoint. For example. if you add a field to
  subjects, it should show up in the fields listed in the output of the
  `/metadata/fields/subject` endpoint.
- [ ] I have confirmed that my field filters correctly when filtered from the
  root endpoint (`/subject`, `/sample`, etc). For example, if you add the
  `anatomical_sites` field to the sample endpoint, make sure that visiting
  `http://localhost:8000/sample?anatomical_sites=foobar` works.
- [ ] I have confirmed that my field shows up in the relevant wiki generation
  command. For example. if you add a field to subjects, it should show up in the
  `cargo run --release wiki subject` output.

-->
