### PR TITLE
feat: update study short title to next version of cde

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Updates the depositions field to be nullable
   ([#140](https://github.com/CBIIT/ccdi-federation-api/pull/140)).
 
+### Revised
+
+- Updates the Study Short Title to use v2.00 of the CDE `11459812`
+  [#142](https://github.com/CBIIT/ccdi-federation-api/pull/142)).
+
 ## [v1.1.0] — 12-17-2024
 
 ### Added

--- a/crates/ccdi-cde/src/v1/namespace.rs
+++ b/crates/ccdi-cde/src/v1/namespace.rs
@@ -4,9 +4,7 @@
 mod study_funding_id;
 mod study_id;
 mod study_name;
-mod study_short_title;
 
 pub use study_funding_id::StudyFundingId;
 pub use study_id::StudyId;
 pub use study_name::StudyName;
-pub use study_short_title::StudyShortTitle;

--- a/crates/ccdi-cde/src/v1/namespace/study_short_title.rs
+++ b/crates/ccdi-cde/src/v1/namespace/study_short_title.rs
@@ -8,14 +8,13 @@ use utoipa::ToSchema;
 
 use crate::CDE;
 
-/// **`caDSR CDE 11459812 v1.00`**
+/// **`caDSR CDE 11459812 v2.00`**
 ///
-/// This metadata element is defined by the caDSR as "The narrative title used
-/// as a textual label for a research data collection. Example – Comparative
-/// Molecular Life History of Spontaneous Canine and Human Gliomas".
+/// This metadata element is defined by the caDSR as "The acronym or
+/// abbreviated form of the title for a research data collection".
 ///
 /// Link:
-/// <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11459812%20and%20ver_nr=1>
+/// <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11459812%20and%20ver_nr=2>
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema, Introspect)]
 #[schema(as = cde::v1::namespace::StudyShortTitle)]
 pub struct StudyShortTitle(String);

--- a/crates/ccdi-cde/src/v2.rs
+++ b/crates/ccdi-cde/src/v2.rs
@@ -1,4 +1,5 @@
 //! Common data elements that have a major version of two.
 
+pub mod namespace;
 pub mod sample;
 pub mod subject;

--- a/crates/ccdi-cde/src/v2/namespace.rs
+++ b/crates/ccdi-cde/src/v2/namespace.rs
@@ -1,0 +1,6 @@
+//! Common data elements that have a major version of two and are related to a
+//! namespace.
+
+mod study_short_title;
+
+pub use study_short_title::StudyShortTitle;

--- a/crates/ccdi-cde/src/v2/namespace/study_short_title.rs
+++ b/crates/ccdi-cde/src/v2/namespace/study_short_title.rs
@@ -16,7 +16,7 @@ use crate::CDE;
 /// Link:
 /// <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11459812%20and%20ver_nr=2>
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema, Introspect)]
-#[schema(as = cde::v1::namespace::StudyShortTitle)]
+#[schema(as = cde::v2::namespace::StudyShortTitle)]
 pub struct StudyShortTitle(String);
 
 impl From<String> for StudyShortTitle {

--- a/crates/ccdi-models/src/metadata/field/description/harmonized/namespace.rs
+++ b/crates/ccdi-models/src/metadata/field/description/harmonized/namespace.rs
@@ -13,14 +13,14 @@ use crate::Url;
 /// Gets the harmonized fields for samples.
 pub fn get_field_descriptions() -> Vec<description::Description> {
     vec![
-        cde::v1::namespace::StudyShortTitle::description(),
+        cde::v2::namespace::StudyShortTitle::description(),
         cde::v1::namespace::StudyId::description(),
         cde::v1::namespace::StudyName::description(),
         cde::v1::namespace::StudyFundingId::description(),
     ]
 }
 
-impl description::r#trait::Description for cde::v1::namespace::StudyShortTitle {
+impl description::r#trait::Description for cde::v2::namespace::StudyShortTitle {
     fn description() -> description::Description {
         let description = match Self::introspected_entity() {
             Entity::Enum(entity) => entity.documentation().unwrap().to_string(),

--- a/crates/ccdi-models/src/metadata/field/unowned.rs
+++ b/crates/ccdi-models/src/metadata/field/unowned.rs
@@ -539,9 +539,9 @@ pub mod namespace {
     unowned_field!(
         StudyShortTitle,
         field::unowned::namespace::StudyShortTitle,
-        cde::v1::namespace::StudyShortTitle,
-        cde::v1::namespace::StudyShortTitle,
-        cde::v1::namespace::StudyShortTitle::from(String::from("A study short title")),
+        cde::v2::namespace::StudyShortTitle,
+        cde::v2::namespace::StudyShortTitle,
+        cde::v2::namespace::StudyShortTitle::from(String::from("A study short title")),
         ccdi_cde as cde
     );
 

--- a/crates/ccdi-models/src/namespace/metadata.rs
+++ b/crates/ccdi-models/src/namespace/metadata.rs
@@ -56,7 +56,7 @@ impl Metadata {
     /// use models::metadata::field::unowned::namespace::StudyShortTitle;
     /// use models::namespace::metadata::Builder;
     ///
-    /// let name = cde::v1::namespace::StudyShortTitle::from(String::from("A study short title"));
+    /// let name = cde::v2::namespace::StudyShortTitle::from(String::from("A study short title"));
     /// let metadata = Builder::default()
     ///     .study_short_title(StudyShortTitle::new(name.clone(), None, None, None))
     ///     .build();

--- a/crates/ccdi-models/src/namespace/metadata/builder.rs
+++ b/crates/ccdi-models/src/namespace/metadata/builder.rs
@@ -41,7 +41,7 @@ impl Builder {
     /// use models::metadata::field::unowned::namespace::StudyShortTitle;
     /// use models::namespace::metadata::Builder;
     ///
-    /// let name = cde::v1::namespace::StudyShortTitle::from(String::from("A study short title"));
+    /// let name = cde::v2::namespace::StudyShortTitle::from(String::from("A study short title"));
     /// let builder =
     ///     Builder::default().study_short_title(StudyShortTitle::new(name, None, None, None));
     /// ```

--- a/crates/ccdi-openapi/src/api.rs
+++ b/crates/ccdi-openapi/src/api.rs
@@ -167,7 +167,7 @@ use utoipa::openapi;
         cde::v1::namespace::StudyFundingId,
         cde::v1::namespace::StudyId,
         cde::v1::namespace::StudyName,
-        cde::v1::namespace::StudyShortTitle,
+        cde::v2::namespace::StudyShortTitle,
 
         // Harmonized organization metadata elements.
         cde::v1::organization::Institution,

--- a/crates/ccdi-server/src/routes/namespace.rs
+++ b/crates/ccdi-server/src/routes/namespace.rs
@@ -46,7 +46,7 @@ lazy_static! {
                 Some(namespace::metadata::Builder::default()
                     .study_short_title(
                         field::unowned::namespace::StudyShortTitle::new(
-                            cde::v1::namespace::StudyShortTitle::from(
+                            cde::v2::namespace::StudyShortTitle::from(
                                 String::from("A study short title")
                             ),
                             None, None, None)
@@ -72,7 +72,7 @@ lazy_static! {
                 Some(namespace::metadata::Builder::default()
                     .study_short_title(
                         field::unowned::namespace::StudyShortTitle::new(
-                            cde::v1::namespace::StudyShortTitle::from(
+                            cde::v2::namespace::StudyShortTitle::from(
                                 String::from("A study short title")
                             ),
                             None, None, None)

--- a/docs/.vitepress/src/api/core.ts
+++ b/docs/.vitepress/src/api/core.ts
@@ -260,14 +260,13 @@ export enum CdeV1NamespaceStudyId {
 export type CdeV1NamespaceStudyName = string;
 
 /**
- * **`caDSR CDE 11459812 v1.00`**
+ * **`caDSR CDE 11459812 v2.00`**
  *
- * This metadata element is defined by the caDSR as "The narrative title used
- * as a textual label for a research data collection. Example – Comparative
- * Molecular Life History of Spontaneous Canine and Human Gliomas".
+ * This metadata element is defined by the caDSR as "The acronym or
+ * abbreviated form of the title for a research data collection".
  *
  * Link:
- * <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11459812%20and%20ver_nr=1>
+ * <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11459812%20and%20ver_nr=2>
  */
 export type CdeV1NamespaceStudyShortTitle = string;
 
@@ -770,14 +769,13 @@ export interface FieldUnownedNamespaceStudyName {
 
 export interface FieldUnownedNamespaceStudyShortTitle {
   /**
-   * **`caDSR CDE 11459812 v1.00`**
+   * **`caDSR CDE 11459812 v2.00`**
    *
-   * This metadata element is defined by the caDSR as "The narrative title used
-   * as a textual label for a research data collection. Example – Comparative
-   * Molecular Life History of Spontaneous Canine and Human Gliomas".
+   * This metadata element is defined by the caDSR as "The acronym or
+   * abbreviated form of the title for a research data collection".
    *
    * Link:
-   * <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11459812%20and%20ver_nr=1>
+   * <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11459812%20and%20ver_nr=2>
    */
   value: CdeV1NamespaceStudyShortTitle;
   /**

--- a/docs/.vitepress/src/api/core.ts
+++ b/docs/.vitepress/src/api/core.ts
@@ -268,7 +268,7 @@ export type CdeV1NamespaceStudyName = string;
  * Link:
  * <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11459812%20and%20ver_nr=2>
  */
-export type CdeV1NamespaceStudyShortTitle = string;
+export type CdeV2NamespaceStudyShortTitle = string;
 
 /**
  * **`caDSR CDE 12662779 v1.00`**
@@ -777,7 +777,7 @@ export interface FieldUnownedNamespaceStudyShortTitle {
    * Link:
    * <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11459812%20and%20ver_nr=2>
    */
-  value: CdeV1NamespaceStudyShortTitle;
+  value: CdeV2NamespaceStudyShortTitle;
   /**
    * The ancestors from which this field was derived.
    *

--- a/swagger.yml
+++ b/swagger.yml
@@ -1289,16 +1289,6 @@ components:
 
         Link:
         <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11459810%20and%20ver_nr=1>
-    cde.v1.namespace.StudyShortTitle:
-      type: string
-      description: |-
-        **`caDSR CDE 11459812 v2.00`**
-
-        This metadata element is defined by the caDSR as "The acronym or
-        abbreviated form of the title for a research data collection".
-
-        Link:
-        <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11459812%20and%20ver_nr=2>
     cde.v1.organization.Institution:
       type: string
       description: |-
@@ -1560,6 +1550,16 @@ components:
       - Dead
       - Unknown
       - Unspecified
+    cde.v2.namespace.StudyShortTitle:
+      type: string
+      description: |-
+        **`caDSR CDE 11459812 v2.00`**
+
+        This metadata element is defined by the caDSR as "The acronym or
+        abbreviated form of the title for a research data collection".
+
+        Link:
+        <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11459812%20and%20ver_nr=2>
     cde.v2.sample.LibrarySelectionMethod:
       type: string
       description: |-
@@ -1861,7 +1861,7 @@ components:
       - value
       properties:
         value:
-          $ref: '#/components/schemas/cde.v1.namespace.StudyShortTitle'
+          $ref: '#/components/schemas/cde.v2.namespace.StudyShortTitle'
         ancestors:
           type: array
           items:

--- a/swagger.yml
+++ b/swagger.yml
@@ -1292,14 +1292,13 @@ components:
     cde.v1.namespace.StudyShortTitle:
       type: string
       description: |-
-        **`caDSR CDE 11459812 v1.00`**
+        **`caDSR CDE 11459812 v2.00`**
 
-        This metadata element is defined by the caDSR as "The narrative title used
-        as a textual label for a research data collection. Example – Comparative
-        Molecular Life History of Spontaneous Canine and Human Gliomas".
+        This metadata element is defined by the caDSR as "The acronym or
+        abbreviated form of the title for a research data collection".
 
         Link:
-        <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11459812%20and%20ver_nr=1>
+        <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11459812%20and%20ver_nr=2>
     cde.v1.organization.Institution:
       type: string
       description: |-


### PR DESCRIPTION
This PR updates the Study Short Title model to use v2.00 of the CDE.

[Discussion](https://github.com/CBIIT/ccdi-federation-api/discussions/69#discussioncomment-12568822)

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional
      Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added a line describing the change in the `CHANGELOG.md` under
      `[Unreleased]`.

<!--

If you are adding new metadata elements, please uncomment this section and
complete the checklist as well:

- [ ] I have added my field definition to the appropriate
  `get_field_descriptions()` method. For example, if you add a field to
  subjects, you should include it in the `get_field_descriptions()` method at
  `crates/ccdi_models/src/metadata/field/description/harmonized/subject.rs`.
- [ ] I have confirmed that my field shows up in the relevant
  `/metadata/fields/<entity>` endpoint. For example. if you add a field to
  subjects, it should show up in the fields listed in the output of the
  `/metadata/fields/subject` endpoint.
- [ ] I have confirmed that my field filters correctly when filtered from the
  root endpoint (`/subject`, `/sample`, etc). For example, if you add the
  `anatomical_sites` field to the sample endpoint, make sure that visiting
  `http://localhost:8000/sample?anatomical_sites=foobar` works.
- [ ] I have confirmed that my field shows up in the relevant wiki generation
  command. For example. if you add a field to subjects, it should show up in the
  `cargo run --release wiki subject` output.

-->
