### PR TITLE
docs: update ccdi-spec serve port documentation

### DIFF
--- a/crates/ccdi-spec/src/main.rs
+++ b/crates/ccdi-spec/src/main.rs
@@ -206,7 +206,7 @@ pub struct ServeArgs {
     #[arg(default_value_t = 1000)]
     number_of_files: usize,
 
-    /// A path to write the output to.
+    /// Port to run the server on.
     #[arg(short = 'p', default_value_t = 8000)]
     port: u16,
 }


### PR DESCRIPTION
This PR just updates the help text around the `ccdi-spec serve` `-p` flag to correctly describe that it is the port and not the path.

This fixes [135](https://github.com/CBIIT/ccdi-federation-api/issues/135).

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional
      Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added a line describing the change in the `CHANGELOG.md` under
      `[Unreleased]`.

<!--

If you are adding new metadata elements, please uncomment this section and
complete the checklist as well:

- [ ] I have added my field definition to the appropriate
  `get_field_descriptions()` method. For example, if you add a field to
  subjects, you should include it in the `get_field_descriptions()` method at
  `crates/ccdi_models/src/metadata/field/description/harmonized/subject.rs`.
- [ ] I have confirmed that my field shows up in the relevant
  `/metadata/fields/<entity>` endpoint. For example. if you add a field to
  subjects, it should show up in the fields listed in the output of the
  `/metadata/fields/subject` endpoint.
- [ ] I have confirmed that my field filters correctly when filtered from the
  root endpoint (`/subject`, `/sample`, etc). For example, if you add the
  `anatomical_sites` field to the sample endpoint, make sure that visiting
  `http://localhost:8000/sample?anatomical_sites=foobar` works.
- [ ] I have confirmed that my field shows up in the relevant wiki generation
  command. For example. if you add a field to subjects, it should show up in the
  `cargo run --release wiki subject` output.

-->
