### PR TITLE
Update `tissue_type` field with new CDE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Revised
 
 - Updates the Study Short Title to use v2.00 of the CDE `11459812`
-  [#142](https://github.com/CBIIT/ccdi-federation-api/pull/142)).
+  ([#142](https://github.com/CBIIT/ccdi-federation-api/pull/142)).
+- Updates sample `tissue_type` field to updated CDE
+  ([discussion](https://github.com/CBIIT/ccdi-federation-api/discussions/39),
+  [#144](https://github.com/CBIIT/ccdi-federation-api/pull/144)).
 
 ## [v1.1.0] — 12-17-2024
 

--- a/crates/ccdi-cde/src/v1/sample.rs
+++ b/crates/ccdi-cde/src/v1/sample.rs
@@ -5,6 +5,7 @@ mod disease_phase;
 mod library_source_material;
 mod library_strategy;
 mod specimen_molecular_analyte_type;
+mod tissue_type;
 mod tumor_classification;
 mod tumor_tissue_morphology;
 
@@ -12,5 +13,6 @@ pub use disease_phase::DiseasePhase;
 pub use library_source_material::LibrarySourceMaterial;
 pub use library_strategy::LibraryStrategy;
 pub use specimen_molecular_analyte_type::SpecimenMolecularAnalyteType;
+pub use tissue_type::TissueType;
 pub use tumor_classification::TumorClassification;
 pub use tumor_tissue_morphology::TumorTissueMorphology;

--- a/crates/ccdi-cde/src/v1/sample/tissue_type.rs
+++ b/crates/ccdi-cde/src/v1/sample/tissue_type.rs
@@ -16,7 +16,7 @@ use crate::CDE;
 /// Link:
 /// <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=14688604%20and%20ver_nr=1>
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema, Introspect)]
-#[schema(as = cde::v2::sample::TissueType)]
+#[schema(as = cde::v1::sample::TissueType)]
 pub enum TissueType {
     /// `Not Reported`
     ///

--- a/crates/ccdi-cde/src/v2/sample.rs
+++ b/crates/ccdi-cde/src/v2/sample.rs
@@ -3,8 +3,6 @@
 
 mod library_selection_method;
 mod preservation_method;
-mod tissue_type;
 
 pub use library_selection_method::LibrarySelectionMethod;
 pub use preservation_method::PreservationMethod;
-pub use tissue_type::TissueType;

--- a/crates/ccdi-cde/src/v2/sample/tissue_type.rs
+++ b/crates/ccdi-cde/src/v2/sample/tissue_type.rs
@@ -7,14 +7,14 @@ use utoipa::ToSchema;
 
 use crate::CDE;
 
-/// **`caDSR CDE 5432687 v2.00`**
+/// **`caDSR CDE 14688604 v1.00`**
 ///
-/// This metadata element is defined by the caDSR as "Text term that represents
-/// a description of the kind of tissue collected with respect to disease status
-/// or proximity to tumor tissue."
+/// This metadata element is defined by the caDSR as "The category assigned to the
+/// cytologic atypia found in cellular molecules, cells, tissues, organs,
+/// body fluids, or body excretory products."
 ///
 /// Link:
-/// <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=5432687%20and%20ver_nr=2>
+/// <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=14688604%20and%20ver_nr=1>
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema, Introspect)]
 #[schema(as = cde::v2::sample::TissueType)]
 pub enum TissueType {
@@ -23,109 +23,58 @@ pub enum TissueType {
     /// * **VM Long Name**: Not Reported
     /// * **VM Public ID**: 5612322
     /// * **Concept Code**: C43234
-    /// * **Begin Date**:   10/03/2023
+    /// * **Begin Date**:   01/18/2024
     ///
     /// Not provided or available.
     #[serde(rename = "Not Reported")]
     NotReported,
 
-    /// `Abnormal`
-    ///
-    /// * **VM Long Name**: Abnormal
-    /// * **VM Public ID**: 4265117
-    /// * **Concept Code**: C25401
-    /// * **Begin Date**:   08/25/2016
-    ///
-    /// Deviating in any way from the state, position, structure, condition,
-    /// behavior, or rule which is considered a norm.
-    #[serde(rename = "Abnormal")]
-    Abnormal,
-
     /// `Normal`
     ///
-    /// * **VM Long Name**: Normal
-    /// * **VM Public ID**: 4494160
-    /// * **Concept Code**: C14165
-    /// * **Begin Date**:   08/25/2016
+    /// * **VM Long Name**: Normal Tissue Sample
+    /// * **VM Public ID**: 14741231
+    /// * **Concept Code**: C162623
+    /// * **Begin Date**:   01/31/2024
     ///
-    /// Being approximately average or within certain limits; conforming with or
-    /// constituting a norm or standard or level or type or social norm.
+    /// Tissue sample with cellular composition and architectural patterns expected
+    /// for the particular anatomic site in which it belongs. There is no evidence
+    /// of abnormal cellular infiltrates or tumor mass formation.
     #[serde(rename = "Normal")]
     Normal,
 
     /// `Peritumoral`
     ///
-    /// * **VM Long Name**: Peritumoral
-    /// * **VM Public ID**: 4633527
-    /// * **Concept Code**: C119010
-    /// * **Begin Date**:   08/25/2016
+    /// * **VM Long Name**: Tumor-Adjacent Normal Specimen
+    /// * **VM Public ID**: 13332906
+    /// * **Concept Code**: C164032
+    /// * **Begin Date**:   01/18/2024
     ///
-    /// Located in tissues surrounding a tumor.
+    /// A specimen comprised of morphologically normal tissue collected from the
+    /// area immediately surrounding a tumor in an experimental subject.
     #[serde(rename = "Peritumoral")]
     Peritumoral,
 
     /// `Tumor`
     ///
-    /// * **VM Long Name**: Malignant Neoplasm
-    /// * **VM Public ID**: 2749852
-    /// * **Concept Code**: C9305
-    /// * **Begin Date**:   /25/2016
+    /// * **VM Long Name**: Tumor Tissue
+    /// * **VM Public ID**: 3184945
+    /// * **Concept Code**: C18009
+    /// * **Begin Date**:   01/31/2024
     ///
-    /// A tumor composed of atypical neoplastic, often pleomorphic cells that
-    /// invade other tissues.  Malignant neoplasms usually metastasize to
-    /// distant anatomic sites and may recur after excision.  The most common
-    /// malignant neoplasms are carcinomas (adenocarcinomas or squamous cell
-    /// carcinomas), Hodgkin's and non-Hodgkin's lymphomas, leukemias,
-    /// melanomas, and sarcomas. -- 2004
+    /// A tissue sample, or entire tumor that is removed for microscopic examination.
     #[serde(rename = "Tumor")]
     Tumor,
-
-    /// `Non-neoplastic`
-    ///
-    /// * **VM Long Name**: Non-Neoplastic
-    /// * **VM Public ID**: 5828001
-    /// * **Concept Code**: C25594:C45315
-    /// * **Begin Date**:   05/16/2017
-    ///
-    /// An operation in which a term denies or inverts the meaning of another
-    /// term or construction.: Exhibiting characteristics of independently
-    /// proliferating cells, notably altered morphology, growth characteristics,
-    /// and/or biochemical and molecular properties.
-    #[serde(rename = "Non-neoplastic")]
-    NonNeoplastic,
-
-    /// `Unavailable`
-    ///
-    /// * **VM Long Name**: Unavailable
-    /// * **VM Public ID**: 5828000
-    /// * **Concept Code**: C126101
-    /// * **Begin Date**:   05/16/2017
-    ///
-    /// The desired information is not available.
-    #[serde(rename = "Unavailable")]
-    Unavailable,
 
     /// `Unknown`
     ///
     /// * **VM Long Name**: Unknown
-    /// * **VM Public ID**: 2572577
+    /// * **VM Public ID**: 5682953
     /// * **Concept Code**: C17998
     /// * **Begin Date**:   05/16/2017
     ///
     /// Not known, not observed, not recorded, or refused.
     #[serde(rename = "Unknown")]
     Unknown,
-
-    /// `Unspecified`
-    ///
-    /// * **VM Long Name**: Unspecified
-    /// * **VM Public ID**: 2573360
-    /// * **Concept Code**: C38046
-    /// * **Begin Date**:   05/16/2017
-    ///
-    /// Not stated explicitly or in detail.
-    #[serde(rename = "Unspecified")]
-    Unspecified,
 }
 
 impl CDE for TissueType {}
@@ -134,30 +83,22 @@ impl std::fmt::Display for TissueType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TissueType::NotReported => write!(f, "Not Reported"),
-            TissueType::Abnormal => write!(f, "Abnormal"),
             TissueType::Normal => write!(f, "Normal"),
             TissueType::Peritumoral => write!(f, "Peritumoral"),
             TissueType::Tumor => write!(f, "Tumor"),
-            TissueType::NonNeoplastic => write!(f, "Non-neoplastic"),
-            TissueType::Unavailable => write!(f, "Unavailable"),
             TissueType::Unknown => write!(f, "Unknown"),
-            TissueType::Unspecified => write!(f, "Unspecified"),
         }
     }
 }
 
 impl Distribution<TissueType> for Standard {
     fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> TissueType {
-        match rng.gen_range(0..=8) {
+        match rng.gen_range(0..=4) {
             0 => TissueType::NotReported,
-            1 => TissueType::Abnormal,
-            2 => TissueType::Normal,
-            3 => TissueType::Peritumoral,
-            4 => TissueType::Tumor,
-            5 => TissueType::NonNeoplastic,
-            6 => TissueType::Unavailable,
-            7 => TissueType::Unknown,
-            _ => TissueType::Unspecified,
+            1 => TissueType::Normal,
+            2 => TissueType::Peritumoral,
+            3 => TissueType::Tumor,
+            _ => TissueType::Unknown,
         }
     }
 }
@@ -169,14 +110,10 @@ mod tests {
     #[test]
     fn it_converts_to_string_correctly() {
         assert_eq!(TissueType::NotReported.to_string(), "Not Reported");
-        assert_eq!(TissueType::Abnormal.to_string(), "Abnormal");
         assert_eq!(TissueType::Normal.to_string(), "Normal");
         assert_eq!(TissueType::Peritumoral.to_string(), "Peritumoral");
         assert_eq!(TissueType::Tumor.to_string(), "Tumor");
-        assert_eq!(TissueType::NonNeoplastic.to_string(), "Non-neoplastic");
-        assert_eq!(TissueType::Unavailable.to_string(), "Unavailable");
         assert_eq!(TissueType::Unknown.to_string(), "Unknown");
-        assert_eq!(TissueType::Unspecified.to_string(), "Unspecified");
     }
 
     #[test]
@@ -184,10 +121,6 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&TissueType::NotReported).unwrap(),
             "\"Not Reported\""
-        );
-        assert_eq!(
-            serde_json::to_string(&TissueType::Abnormal).unwrap(),
-            "\"Abnormal\""
         );
         assert_eq!(
             serde_json::to_string(&TissueType::Normal).unwrap(),
@@ -202,20 +135,8 @@ mod tests {
             "\"Tumor\""
         );
         assert_eq!(
-            serde_json::to_string(&TissueType::NonNeoplastic).unwrap(),
-            "\"Non-neoplastic\""
-        );
-        assert_eq!(
-            serde_json::to_string(&TissueType::Unavailable).unwrap(),
-            "\"Unavailable\""
-        );
-        assert_eq!(
             serde_json::to_string(&TissueType::Unknown).unwrap(),
             "\"Unknown\""
-        );
-        assert_eq!(
-            serde_json::to_string(&TissueType::Unspecified).unwrap(),
-            "\"Unspecified\""
         );
     }
 }

--- a/crates/ccdi-models/src/metadata/field/description/harmonized/sample.rs
+++ b/crates/ccdi-models/src/metadata/field/description/harmonized/sample.rs
@@ -25,7 +25,7 @@ pub fn get_field_descriptions() -> Vec<description::Description> {
         cde::v1::sample::LibrarySourceMaterial::description(),
         cde::v2::sample::PreservationMethod::description(),
         cde::v1::sample::SpecimenMolecularAnalyteType::description(),
-        cde::v2::sample::TissueType::description(),
+        cde::v1::sample::TissueType::description(),
         cde::v1::sample::TumorClassification::description(),
         cde::v1::sample::TumorTissueMorphology::description(),
         crate::sample::metadata::AgeAtCollection::description(),
@@ -213,7 +213,7 @@ impl description::r#trait::Description for cde::v1::sample::SpecimenMolecularAna
     }
 }
 
-impl description::r#trait::Description for cde::v2::sample::TissueType {
+impl description::r#trait::Description for cde::v1::sample::TissueType {
     fn description() -> description::Description {
         // SAFETY: these two unwraps are tested statically below in the test
         // that constructs the description using `get_fields()`.

--- a/crates/ccdi-models/src/metadata/field/unowned.rs
+++ b/crates/ccdi-models/src/metadata/field/unowned.rs
@@ -295,9 +295,9 @@ pub mod sample {
     unowned_field!(
         TissueType,
         field::unowned::sample::TissueType,
-        cde::v2::sample::TissueType,
-        cde::v2::sample::TissueType,
-        cde::v2::sample::TissueType::Tumor,
+        cde::v1::sample::TissueType,
+        cde::v1::sample::TissueType,
+        cde::v1::sample::TissueType::Tumor,
         ccdi_cde as cde
     );
 

--- a/crates/ccdi-models/src/sample/metadata.rs
+++ b/crates/ccdi-models/src/sample/metadata.rs
@@ -418,7 +418,7 @@ impl Metadata {
     ///
     /// let metadata = Builder::default()
     ///     .tissue_type(TissueType::new(
-    ///         cde::v2::sample::TissueType::Tumor,
+    ///         cde::v1::sample::TissueType::Tumor,
     ///         None,
     ///         None,
     ///         None,
@@ -428,7 +428,7 @@ impl Metadata {
     /// assert_eq!(
     ///     metadata.tissue_type(),
     ///     Some(&TissueType::new(
-    ///         cde::v2::sample::TissueType::Tumor,
+    ///         cde::v1::sample::TissueType::Tumor,
     ///         None,
     ///         None,
     ///         None

--- a/crates/ccdi-models/src/sample/metadata/builder.rs
+++ b/crates/ccdi-models/src/sample/metadata/builder.rs
@@ -193,7 +193,7 @@ impl Builder {
     /// use models::metadata::field::unowned::sample::TissueType;
     /// use models::sample::metadata::Builder;
     ///
-    /// let field = TissueType::new(cde::v2::sample::TissueType::Tumor, None, None, None);
+    /// let field = TissueType::new(cde::v1::sample::TissueType::Tumor, None, None, None);
     /// let builder = Builder::default().tissue_type(field);
     /// ```
     pub fn tissue_type(mut self, field: field::unowned::sample::TissueType) -> Self {

--- a/crates/ccdi-openapi/src/api.rs
+++ b/crates/ccdi-openapi/src/api.rs
@@ -146,7 +146,7 @@ use utoipa::openapi;
         cde::v1::sample::LibrarySourceMaterial,
         cde::v2::sample::PreservationMethod,
         cde::v1::sample::SpecimenMolecularAnalyteType,
-        cde::v2::sample::TissueType,
+        cde::v1::sample::TissueType,
         cde::v1::sample::TumorClassification,
         cde::v1::sample::TumorTissueMorphology,
         models::sample::metadata::AgeAtCollection,

--- a/docs/.vitepress/src/api/core.ts
+++ b/docs/.vitepress/src/api/core.ts
@@ -400,6 +400,24 @@ export enum CdeV1SampleLibraryStrategy {
 }
 
 /**
+ * **`caDSR CDE 14688604 v1.00`**
+ *
+ * This metadata element is defined by the caDSR as "The category assigned
+ * to the cytologic atypia found in cellular molecules, cells, tissues, organs,
+ * body fluids, or body excretory products."
+ *
+ * Link:
+ * <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=14688604%20and%20ver_nr=1>
+ */
+export enum CdeV1SampleTissueType {
+  NotReported = "Not Reported",
+  Normal = "Normal",
+  Peritumoral = "Peritumoral",
+  Tumor = "Tumor",
+  Unknown = "Unknown",
+}
+
+/**
  * **`caDSR CDE 12922545 v1.00`**
  *
  * This metadata element is defined by the caDSR as "The classification of a
@@ -530,24 +548,6 @@ export enum CdeV2SamplePreservationMethod {
   NotReported = "Not Reported",
   OCT = "OCT",
   SnapFrozen = "Snap Frozen",
-  Unknown = "Unknown",
-}
-
-/**
- * **`caDSR CDE 14688604 v1.00`**
- *
- * This metadata element is defined by the caDSR as "The category assigned
- * to the cytologic atypia found in cellular molecules, cells, tissues, organs,
- * body fluids, or body excretory products."
- *
- * Link:
- * <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=14688604%20and%20ver_nr=1>
- */
-export enum CdeV2SampleTissueType {
-  NotReported = "Not Reported",
-  Normal = "Normal",
-  Peritumoral = "Peritumoral",
-  Tumor = "Tumor",
   Unknown = "Unknown",
 }
 
@@ -995,7 +995,7 @@ export interface FieldUnownedSampleTissueType {
    * Link:
    * <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=14688604%20and%20ver_nr=1>
    */
-  value: CdeV2SampleTissueType;
+  value: CdeV1SampleTissueType;
   /**
    * The ancestors from which this field was derived.
    *

--- a/docs/.vitepress/src/api/core.ts
+++ b/docs/.vitepress/src/api/core.ts
@@ -534,25 +534,21 @@ export enum CdeV2SamplePreservationMethod {
 }
 
 /**
- * **`caDSR CDE 5432687 v2.00`**
+ * **`caDSR CDE 14688604 v1.00`**
  *
- * This metadata element is defined by the caDSR as "Text term that represents
- * a description of the kind of tissue collected with respect to disease status
- * or proximity to tumor tissue."
+ * This metadata element is defined by the caDSR as "The category assigned
+ * to the cytologic atypia found in cellular molecules, cells, tissues, organs,
+ * body fluids, or body excretory products."
  *
  * Link:
- * <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=5432687%20and%20ver_nr=2>
+ * <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=14688604%20and%20ver_nr=1>
  */
 export enum CdeV2SampleTissueType {
   NotReported = "Not Reported",
-  Abnormal = "Abnormal",
   Normal = "Normal",
   Peritumoral = "Peritumoral",
   Tumor = "Tumor",
-  NonNeoplastic = "Non-neoplastic",
-  Unavailable = "Unavailable",
   Unknown = "Unknown",
-  Unspecified = "Unspecified",
 }
 
 /**
@@ -990,14 +986,14 @@ export interface FieldUnownedSamplePreservationMethod {
 
 export interface FieldUnownedSampleTissueType {
   /**
-   * **`caDSR CDE 5432687 v2.00`**
+   * **`caDSR CDE 14688604 v1.00`**
    *
-   * This metadata element is defined by the caDSR as "Text term that represents
-   * a description of the kind of tissue collected with respect to disease status
-   * or proximity to tumor tissue."
+   * This metadata element is defined by the caDSR as "The category assigned to the
+   * cytologic atypia found in cellular molecules, cells, tissues, organs,
+   * body fluids, or body excretory products."
    *
    * Link:
-   * <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=5432687%20and%20ver_nr=2>
+   * <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=14688604%20and%20ver_nr=1>
    */
   value: CdeV2SampleTissueType;
   /**

--- a/swagger.yml
+++ b/swagger.yml
@@ -1612,24 +1612,20 @@ components:
     cde.v2.sample.TissueType:
       type: string
       description: |-
-        **`caDSR CDE 5432687 v2.00`**
+        **`caDSR CDE 14688604 v1.00`**
 
-        This metadata element is defined by the caDSR as "Text term that represents
-        a description of the kind of tissue collected with respect to disease status
-        or proximity to tumor tissue."
+        This metadata element is defined by the caDSR as "The category assigned to the
+        cytologic atypia found in cellular molecules, cells, tissues, organs,
+        body fluids, or body excretory products."
 
         Link:
-        <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=5432687%20and%20ver_nr=2>
+        <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=14688604%20and%20ver_nr=1>
       enum:
       - Not Reported
-      - Abnormal
       - Normal
       - Peritumoral
       - Tumor
-      - Non-neoplastic
-      - Unavailable
       - Unknown
-      - Unspecified
     cde.v2.subject.Ethnicity:
       type: string
       description: |-

--- a/swagger.yml
+++ b/swagger.yml
@@ -1447,6 +1447,23 @@ components:
       - Protein
       - DNA
       - RNA
+    cde.v1.sample.TissueType:
+      type: string
+      description: |-
+        **`caDSR CDE 14688604 v1.00`**
+
+        This metadata element is defined by the caDSR as "The category assigned to the
+        cytologic atypia found in cellular molecules, cells, tissues, organs,
+        body fluids, or body excretory products."
+
+        Link:
+        <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=14688604%20and%20ver_nr=1>
+      enum:
+      - Not Reported
+      - Normal
+      - Peritumoral
+      - Tumor
+      - Unknown
     cde.v1.sample.TumorClassification:
       type: string
       description: |-
@@ -1608,23 +1625,6 @@ components:
       - Not Reported
       - OCT
       - Snap Frozen
-      - Unknown
-    cde.v2.sample.TissueType:
-      type: string
-      description: |-
-        **`caDSR CDE 14688604 v1.00`**
-
-        This metadata element is defined by the caDSR as "The category assigned to the
-        cytologic atypia found in cellular molecules, cells, tissues, organs,
-        body fluids, or body excretory products."
-
-        Link:
-        <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=14688604%20and%20ver_nr=1>
-      enum:
-      - Not Reported
-      - Normal
-      - Peritumoral
-      - Tumor
       - Unknown
     cde.v2.subject.Ethnicity:
       type: string
@@ -2143,7 +2143,7 @@ components:
       - value
       properties:
         value:
-          $ref: '#/components/schemas/cde.v2.sample.TissueType'
+          $ref: '#/components/schemas/cde.v1.sample.TissueType'
         ancestors:
           type: array
           items:


### PR DESCRIPTION
This PR updates the `tissue_type` sample field with a new CDE that is not retired. The values of the new CDE are a bit different from the previous one.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional
      Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added a line describing the change in the `CHANGELOG.md` under
      `[Unreleased]`.

<!--

If you are adding new metadata elements, please uncomment this section and
complete the checklist as well:

- [ ] I have added my field definition to the appropriate
  `get_field_descriptions()` method. For example, if you add a field to
  subjects, you should include it in the `get_field_descriptions()` method at
  `crates/ccdi_models/src/metadata/field/description/harmonized/subject.rs`.
- [ ] I have confirmed that my field shows up in the relevant
  `/metadata/fields/<entity>` endpoint. For example. if you add a field to
  subjects, it should show up in the fields listed in the output of the
  `/metadata/fields/subject` endpoint.
- [ ] I have confirmed that my field filters correctly when filtered from the
  root endpoint (`/subject`, `/sample`, etc). For example, if you add the
  `anatomical_sites` field to the sample endpoint, make sure that visiting
  `http://localhost:8000/sample?anatomical_sites=foobar` works.
- [ ] I have confirmed that my field shows up in the relevant wiki generation
  command. For example. if you add a field to subjects, it should show up in the
  `cargo run --release wiki subject` output.

-->
