### PR TITLE
feat: add Sample ID CDE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Adds Sample ID CDE description to the `name`
+  ([discussion](https://github.com/CBIIT/ccdi-federation-api/discussions/136),
+  [#148](https://github.com/CBIIT/ccdi-federation-api/pull/148)).
+
 ### Fixed
 
 - Corrects the duplicated `Black or African Amercian` race description

--- a/crates/ccdi-models/src/sample/identifier.rs
+++ b/crates/ccdi-models/src/sample/identifier.rs
@@ -22,7 +22,13 @@ pub struct Identifier {
     #[schema(value_type = models::namespace::Identifier)]
     namespace: namespace::Identifier,
 
-    /// The name of the identifier.
+    /// **`caDSR CDE 15100774 v1.00`**
+    ///
+    /// This metadata element is defined by the caDSR as "A unique string of characters
+    /// used to identify a specimen.".
+    ///
+    /// Link:
+    /// <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=15100774%20and%20ver_nr=1>
     #[schema(example = "SampleName001")]
     name: String,
 }

--- a/docs/.vitepress/src/api/core.ts
+++ b/docs/.vitepress/src/api/core.ts
@@ -2124,7 +2124,13 @@ export interface ModelsSampleIdentifier {
   /** An identifier for a namespace. */
   namespace: ModelsNamespaceIdentifier;
   /**
-   * The name of the identifier.
+   * **`caDSR CDE 15100774 v1.00`**
+   *
+   * This metadata element is defined by the caDSR as "A unique string of characters
+   * used to identify a specimen.".
+   *
+   * Link:
+   * <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=15100774%20and%20ver_nr=1>
    * @example "SampleName001"
    */
   name: string;

--- a/swagger.yml
+++ b/swagger.yml
@@ -3300,7 +3300,14 @@ components:
           $ref: '#/components/schemas/models.namespace.Identifier'
         name:
           type: string
-          description: The name of the identifier.
+          description: |-
+            **`caDSR CDE 15100774 v1.00`**
+
+            This metadata element is defined by the caDSR as "A unique string of characters
+            used to identify a specimen.".
+
+            Link:
+            <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=15100774%20and%20ver_nr=1>
           example: SampleName001
     models.sample.Metadata:
       allOf:


### PR DESCRIPTION
This PR adds the sample ID CDE documentation to the `name` section of the `Sample.Identifier` element. This CDE is different from the others as we don't have a field for Sample ID exactly, but rather the Sample.Identifier field contains both the `namespace` object and the `name` field and this CDE is only relevant to the `name`. So, I've opted to just add it to the documentation of the `name` field.

In Rust, there also seems to be no straightforward way to specify that the string be 25 characters long as it is a runtime check.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional
      Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [ ] ~~You have updated the README or other documentation to account for these
      changes (when appropriate).~~
- [ ] You have added a line describing the change in the `CHANGELOG.md` under
      `[Unreleased]`.

<!--

If you are adding new metadata elements, please uncomment this section and
complete the checklist as well:

- [ ] I have added my field definition to the appropriate
  `get_field_descriptions()` method. For example, if you add a field to
  subjects, you should include it in the `get_field_descriptions()` method at
  `crates/ccdi_models/src/metadata/field/description/harmonized/subject.rs`.
- [ ] I have confirmed that my field shows up in the relevant
  `/metadata/fields/<entity>` endpoint. For example. if you add a field to
  subjects, it should show up in the fields listed in the output of the
  `/metadata/fields/subject` endpoint.
- [ ] I have confirmed that my field filters correctly when filtered from the
  root endpoint (`/subject`, `/sample`, etc). For example, if you add the
  `anatomical_sites` field to the sample endpoint, make sure that visiting
  `http://localhost:8000/sample?anatomical_sites=foobar` works.
- [ ] I have confirmed that my field shows up in the relevant wiki generation
  command. For example. if you add a field to subjects, it should show up in the
  `cargo run --release wiki subject` output.

-->
