### PR TITLE
feat: add tumor grade to sample endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Adds Sample ID CDE description to the `name`
   ([discussion](https://github.com/CBIIT/ccdi-federation-api/discussions/136),
   [#148](https://github.com/CBIIT/ccdi-federation-api/pull/148)).
+- Adds Tumor Grade
+  ([discussion](https://github.com/CBIIT/ccdi-federation-api/discussions/137),
+  [#149](https://github.com/CBIIT/ccdi-federation-api/pull/149)).
 
 ### Fixed
 

--- a/crates/ccdi-cde/src/v2/sample.rs
+++ b/crates/ccdi-cde/src/v2/sample.rs
@@ -3,6 +3,8 @@
 
 mod library_selection_method;
 mod preservation_method;
+mod tumor_grade;
 
 pub use library_selection_method::LibrarySelectionMethod;
 pub use preservation_method::PreservationMethod;
+pub use tumor_grade::TumorGrade;

--- a/crates/ccdi-cde/src/v2/sample/tumor_grade.rs
+++ b/crates/ccdi-cde/src/v2/sample/tumor_grade.rs
@@ -1,0 +1,224 @@
+use introspect::Introspect;
+use rand::distributions::Standard;
+use rand::prelude::Distribution;
+use serde::Deserialize;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use crate::CDE;
+
+/// **`caDSR CDE 11325685 v2.00`**
+///
+/// This metadata element is defined by the caDSR as "A text term to express
+/// the degree of abnormality of cancer cells as a measure of differentiation
+/// and aggressiveness.".
+///
+/// Link:
+/// <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11325685%20and%20ver_nr=2>
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema, Introspect)]
+#[schema(as = cde::v2::sample::TumorGrade)]
+pub enum TumorGrade {
+    /// `G1 Low Grade`
+    ///
+    /// * **VM Long Name**: Grade 1
+    /// * **VM Public ID**: 13270009
+    /// * **Concept Code**: C28077
+    /// * **Begin Date**:   03/03/2025
+    ///
+    /// A morphologic qualifier indicating that a cancerous lesion is
+    /// well differentiated.
+    #[serde(rename = "G1 Low Grade")]
+    G1LowGrade,
+
+    /// `G2 Intermediate Grade`
+    ///
+    /// * **VM Long Name**: Grade 2
+    /// * **VM Public ID**: 5622672
+    /// * **Concept Code**: C28078
+    /// * **Begin Date**:   03/03/2025
+    ///
+    /// A morphologic qualifier indicating that a cancerous lesion is
+    /// moderately differentiated.
+    #[serde(rename = "G2 Intermediate Grade")]
+    G2IntermediateGrade,
+
+    /// `G3 High Grade`
+    ///
+    /// * **VM Long Name**: Grade 3
+    /// * **VM Public ID**: 5622671
+    /// * **Concept Code**: C28079
+    /// * **Begin Date**:   03/03/2025
+    ///
+    /// A morphologic qualifier indicating that a cancerous lesion is
+    /// poorly differentiated.
+    #[serde(rename = "G3 High Grade")]
+    G3HighGrade,
+
+    /// `G4 Anaplastic`
+    ///
+    /// * **VM Long Name**: Grade 4
+    /// * **VM Public ID**: 15872601
+    /// * **Concept Code**: C28082
+    /// * **Begin Date**:   03/03/2025
+    ///
+    /// A morphologic qualifier indicating that a cancerous lesion is
+    /// undifferentiated.
+    #[serde(rename = "G4 Anaplastic")]
+    G4Anaplastic,
+
+    /// `GB Borderline`
+    ///
+    /// * **VM Long Name**: Grade B
+    /// * **VM Public ID**: 6050322
+    /// * **Concept Code**: C113729
+    /// * **Begin Date**:   09/27/2022
+    ///
+    /// A morphologic qualifier indicating that a neoplasm is of
+    /// borderline malignancy.
+    #[serde(rename = "GB Borderline")]
+    GBBorderline,
+
+    /// `GX Grade Cannot Be Assessed`
+    ///
+    /// * **VM Long Name**: Grade X
+    /// * **VM Public ID**: 10987209
+    /// * **Concept Code**: C113730
+    /// * **Begin Date**:   09/27/2022
+    ///
+    /// A morphologic qualifier indicating that the grade of a
+    /// neoplasm cannot be assessed.
+    #[serde(rename = "GX Grade Cannot Be Assessed")]
+    GXGrade,
+
+    /// `Not Applicable`
+    ///
+    /// * **VM Long Name**: Not Applicable
+    /// * **VM Public ID**: 7590024
+    /// * **Concept Code**: C48660
+    /// * **Begin Date**:   09/27/2022
+    ///
+    /// Determination of a value is not relevant in the current
+    /// context.
+    #[serde(rename = "Not Applicable")]
+    NotApplicable,
+
+    /// `Not Reported`
+    ///
+    /// * **VM Long Name**: Not Reported
+    /// * **VM Public ID**: 5612322
+    /// * **Concept Code**: C43234
+    /// * **Begin Date**:   03/27/2023
+    ///
+    /// Not provided or available.
+    #[serde(rename = "Not Reported")]
+    NotReported,
+
+    /// `Unknown`
+    ///
+    /// * **VM Long Name**: Unknown
+    /// * **VM Public ID**: 5682953
+    /// * **Concept Code**: C17998
+    /// * **Begin Date**:   07/30/2023
+    ///
+    /// Not known, not observed, not recorded, or refused.
+    #[serde(rename = "Unknown")]
+    Unknown,
+}
+
+impl CDE for TumorGrade {}
+
+impl std::fmt::Display for TumorGrade {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TumorGrade::G1LowGrade => write!(f, "G1 Low Grade"),
+            TumorGrade::G2IntermediateGrade => write!(f, "G2 Intermediate Grade"),
+            TumorGrade::G3HighGrade => write!(f, "G3 High Grade"),
+            TumorGrade::G4Anaplastic => write!(f, "G4 Anaplastic"),
+            TumorGrade::GBBorderline => write!(f, "GB Borderline"),
+            TumorGrade::GXGrade => write!(f, "GX Grade Cannot Be Assessed"),
+            TumorGrade::NotApplicable => write!(f, "Not Applicable"),
+            TumorGrade::NotReported => write!(f, "Not Reported"),
+            TumorGrade::Unknown => write!(f, "Unknown"),
+        }
+    }
+}
+
+impl Distribution<TumorGrade> for Standard {
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> TumorGrade {
+        match rng.gen_range(0..9) {
+            0 => TumorGrade::G1LowGrade,
+            1 => TumorGrade::G2IntermediateGrade,
+            2 => TumorGrade::G3HighGrade,
+            3 => TumorGrade::G4Anaplastic,
+            4 => TumorGrade::GBBorderline,
+            5 => TumorGrade::GXGrade,
+            6 => TumorGrade::NotApplicable,
+            7 => TumorGrade::NotReported,
+            _ => TumorGrade::Unknown,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_converts_to_string_correctly() {
+        assert_eq!(TumorGrade::G1LowGrade.to_string(), "G1 Low Grade");
+        assert_eq!(
+            TumorGrade::G2IntermediateGrade.to_string(),
+            "G2 Intermediate Grade"
+        );
+        assert_eq!(TumorGrade::G3HighGrade.to_string(), "G3 High Grade");
+        assert_eq!(TumorGrade::G4Anaplastic.to_string(), "G4 Anaplastic");
+        assert_eq!(TumorGrade::GBBorderline.to_string(), "GB Borderline");
+        assert_eq!(
+            TumorGrade::GXGrade.to_string(),
+            "GX Grade Cannot Be Assessed"
+        );
+        assert_eq!(TumorGrade::NotApplicable.to_string(), "Not Applicable");
+        assert_eq!(TumorGrade::NotReported.to_string(), "Not Reported");
+        assert_eq!(TumorGrade::Unknown.to_string(), "Unknown");
+    }
+
+    #[test]
+    fn it_serializes_to_json_correctly() {
+        assert_eq!(
+            serde_json::to_string(&TumorGrade::G1LowGrade).unwrap(),
+            "\"G1 Low Grade\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TumorGrade::G2IntermediateGrade).unwrap(),
+            "\"G2 Intermediate Grade\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TumorGrade::G3HighGrade).unwrap(),
+            "\"G3 High Grade\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TumorGrade::G4Anaplastic).unwrap(),
+            "\"G4 Anaplastic\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TumorGrade::GBBorderline).unwrap(),
+            "\"GB Borderline\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TumorGrade::GXGrade).unwrap(),
+            "\"GX Grade Cannot Be Assessed\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TumorGrade::NotApplicable).unwrap(),
+            "\"Not Applicable\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TumorGrade::NotReported).unwrap(),
+            "\"Not Reported\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TumorGrade::Unknown).unwrap(),
+            "\"Unknown\""
+        );
+    }
+}

--- a/crates/ccdi-models/src/metadata/field/description/harmonized/sample.rs
+++ b/crates/ccdi-models/src/metadata/field/description/harmonized/sample.rs
@@ -24,6 +24,7 @@ pub fn get_field_descriptions() -> Vec<description::Description> {
         cde::v1::sample::LibraryStrategy::description(),
         cde::v1::sample::LibrarySourceMaterial::description(),
         cde::v2::sample::PreservationMethod::description(),
+        cde::v2::sample::TumorGrade::description(),
         cde::v1::sample::SpecimenMolecularAnalyteType::description(),
         cde::v1::sample::TissueType::description(),
         cde::v1::sample::TumorClassification::description(),
@@ -180,6 +181,29 @@ impl description::r#trait::Description for cde::v2::sample::PreservationMethod {
             String::from("preservation_method"),
             entity.description().to_string(),
             "https://github.com/CBIIT/ccdi-federation-api/wiki/Sample-Metadata-Fields#preservation_method"
+                .parse::<Url>()
+                .unwrap(),
+            Some(Standard::new(
+                entity.standard_name().to_string(),
+                crate::Url::from(entity.standard_url().clone()),
+            )),
+            members,
+        ))
+    }
+}
+
+impl description::r#trait::Description for cde::v2::sample::TumorGrade {
+    fn description() -> description::Description {
+        // SAFETY: these two unwraps are tested statically below in the test
+        // that constructs the description using `get_fields()`.
+        let entity = Self::entity().unwrap();
+        let members = Self::members().map(|member| member.unwrap());
+
+        description::Description::Harmonized(Harmonized::new(
+            Kind::Enum,
+            String::from("tumor_grade"),
+            entity.description().to_string(),
+            "https://github.com/CBIIT/ccdi-federation-api/wiki/Sample-Metadata-Fields#tumor_grade"
                 .parse::<Url>()
                 .unwrap(),
             Some(Standard::new(

--- a/crates/ccdi-models/src/metadata/field/unowned.rs
+++ b/crates/ccdi-models/src/metadata/field/unowned.rs
@@ -347,6 +347,15 @@ pub mod sample {
     );
 
     unowned_field!(
+        TumorGrade,
+        field::unowned::sample::TumorGrade,
+        cde::v2::sample::TumorGrade,
+        cde::v2::sample::TumorGrade,
+        cde::v2::sample::TumorGrade::Unknown,
+        ccdi_cde as cde
+    );
+
+    unowned_field!(
         SpecimenMolecularAnalyteType,
         field::unowned::sample::SpecimenMolecularAnalyteType,
         cde::v1::sample::SpecimenMolecularAnalyteType,

--- a/crates/ccdi-models/src/sample/metadata.rs
+++ b/crates/ccdi-models/src/sample/metadata.rs
@@ -81,6 +81,10 @@ pub struct Metadata {
     #[schema(value_type = field::unowned::sample::PreservationMethod, nullable = true)]
     preservation_method: Option<field::unowned::sample::PreservationMethod>,
 
+    /// The tumor grade for a sample.
+    #[schema(value_type = field::unowned::sample::TumorGrade, nullable = true)]
+    tumor_grade: Option<field::unowned::sample::TumorGrade>,
+
     /// The sample or material being subjected to analysis.
     #[schema(value_type = field::unowned::sample::SpecimenMolecularAnalyteType, nullable = true)]
     specimen_molecular_analyte_type: Option<field::unowned::sample::SpecimenMolecularAnalyteType>,
@@ -367,6 +371,39 @@ impl Metadata {
     /// ```
     pub fn preservation_method(&self) -> Option<&field::unowned::sample::PreservationMethod> {
         self.preservation_method.as_ref()
+    }
+    /// Gets the harmonized tumor grade for the [`Metadata`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_cde as cde;
+    /// use ccdi_models as models;
+    ///
+    /// use models::metadata::field::unowned::sample::TumorGrade;
+    /// use models::sample::metadata::Builder;
+    ///
+    /// let metadata = Builder::default()
+    ///     .tumor_grade(TumorGrade::new(
+    ///         cde::v2::sample::TumorGrade::G1LowGrade,
+    ///         None,
+    ///         None,
+    ///         None,
+    ///     ))
+    ///     .build();
+    ///
+    /// assert_eq!(
+    ///     metadata.tumor_grade(),
+    ///     Some(&TumorGrade::new(
+    ///         cde::v2::sample::TumorGrade::G1LowGrade,
+    ///         None,
+    ///         None,
+    ///         None,
+    ///     ))
+    /// );
+    /// ```
+    pub fn tumor_grade(&self) -> Option<&field::unowned::sample::TumorGrade> {
+        self.tumor_grade.as_ref()
     }
 
     /// Gets the harmonized specimen molecular analyte type for the [`Metadata`].
@@ -736,6 +773,7 @@ impl Metadata {
             library_strategy: rand::random(),
             library_source_material: rand::random(),
             preservation_method: rand::random(),
+            tumor_grade: rand::random(),
             specimen_molecular_analyte_type: rand::random(),
             tissue_type: rand::random(),
             tumor_classification: rand::random(),
@@ -795,7 +833,7 @@ mod tests {
         let metadata = builder::Builder::default().build();
         assert_eq!(
             &serde_json::to_string(&metadata).unwrap(),
-            "{\"age_at_diagnosis\":null,\"anatomical_sites\":null,\"diagnosis\":null,\"disease_phase\":null,\"library_selection_method\":null,\"tissue_type\":null,\"tumor_classification\":null,\"tumor_tissue_morphology\":null,\"age_at_collection\":null,\"library_strategy\":null,\"library_source_material\":null,\"preservation_method\":null,\"specimen_molecular_analyte_type\":null,\"identifiers\":null,\"depositions\":null}"
+            "{\"age_at_diagnosis\":null,\"anatomical_sites\":null,\"diagnosis\":null,\"disease_phase\":null,\"library_selection_method\":null,\"tissue_type\":null,\"tumor_classification\":null,\"tumor_tissue_morphology\":null,\"age_at_collection\":null,\"library_strategy\":null,\"library_source_material\":null,\"preservation_method\":null,\"tumor_grade\":null,\"specimen_molecular_analyte_type\":null,\"identifiers\":null,\"depositions\":null}"
         );
     }
 }

--- a/crates/ccdi-models/src/sample/metadata/builder.rs
+++ b/crates/ccdi-models/src/sample/metadata/builder.rs
@@ -45,6 +45,9 @@ pub struct Builder {
     /// The preservation method for this sample or biospecimen.
     preservation_method: Option<field::unowned::sample::PreservationMethod>,
 
+    /// The tumor grade for this sample.
+    tumor_grade: Option<field::unowned::sample::TumorGrade>,
+
     /// The specimen molecular analyte type for this sample.
     specimen_molecular_analyte_type: Option<field::unowned::sample::SpecimenMolecularAnalyteType>,
 
@@ -350,6 +353,25 @@ impl Builder {
         self
     }
 
+    /// Sets the `tumor_grade` field of the [`Builder`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ccdi_cde as cde;
+    /// use ccdi_models as models;
+    ///
+    /// use models::metadata::field::unowned::sample::TumorGrade;
+    /// use models::sample::metadata::Builder;
+    ///
+    /// let field = TumorGrade::new(cde::v2::sample::TumorGrade::Unknown, None, None, None);
+    /// let builder = Builder::default().tumor_grade(field);
+    /// ```
+    pub fn tumor_grade(mut self, field: field::unowned::sample::TumorGrade) -> Self {
+        self.tumor_grade = Some(field);
+        self
+    }
+
     /// Sets the `specimen_molecular_analyte_type` field of the [`Builder`].
     ///
     /// # Examples
@@ -531,6 +553,7 @@ impl Builder {
             library_strategy: self.library_strategy,
             library_source_material: self.library_source_material,
             preservation_method: self.preservation_method,
+            tumor_grade: self.tumor_grade,
             specimen_molecular_analyte_type: self.specimen_molecular_analyte_type,
             tissue_type: self.tissue_type,
             tumor_classification: self.tumor_classification,

--- a/crates/ccdi-openapi/src/api.rs
+++ b/crates/ccdi-openapi/src/api.rs
@@ -148,6 +148,7 @@ use utoipa::openapi;
         cde::v1::sample::SpecimenMolecularAnalyteType,
         cde::v1::sample::TissueType,
         cde::v1::sample::TumorClassification,
+        cde::v2::sample::TumorGrade,
         cde::v1::sample::TumorTissueMorphology,
         models::sample::metadata::AgeAtCollection,
 
@@ -194,6 +195,7 @@ use utoipa::openapi;
         field::unowned::sample::SpecimenMolecularAnalyteType,
         field::unowned::sample::TissueType,
         field::unowned::sample::TumorClassification,
+        field::unowned::sample::TumorGrade,
         field::unowned::sample::TumorTissueMorphology,
         field::unowned::sample::AgeAtCollection,
         field::unowned::sample::Identifier,

--- a/crates/ccdi-server/src/filter/sample.rs
+++ b/crates/ccdi-server/src/filter/sample.rs
@@ -17,6 +17,7 @@ impl FilterMetadataField<Sample, FilterSampleParams> for Vec<Sample> {
             "library_strategy" => params.library_strategy.as_ref(),
             "library_source_material" => params.library_source_material.as_ref(),
             "preservation_method" => params.preservation_method.as_ref(),
+            "tumor_grade" => params.tumor_grade.as_ref(),
             "specimen_molecular_analyte_type" => params.specimen_molecular_analyte_type.as_ref(),
             "tissue_type" => params.tissue_type.as_ref(),
             "tumor_classification" => params.tumor_classification.as_ref(),
@@ -66,6 +67,10 @@ impl FilterMetadataField<Sample, FilterSampleParams> for Vec<Sample> {
                         .metadata()
                         .and_then(|metadata| metadata.preservation_method())
                         .map(|preservation_method| vec![preservation_method.to_string()]),
+                    "tumor_grade" => sample
+                        .metadata()
+                        .and_then(|metadata| metadata.tumor_grade())
+                        .map(|tumor_grade| vec![tumor_grade.to_string()]),
                     "specimen_molecular_analyte_type" => sample
                         .metadata()
                         .and_then(|metadata| metadata.specimen_molecular_analyte_type())

--- a/crates/ccdi-server/src/params/filter.rs
+++ b/crates/ccdi-server/src/params/filter.rs
@@ -117,6 +117,12 @@ pub struct Sample {
     #[param(required = false, nullable = false)]
     pub preservation_method: Option<String>,
 
+    /// Matches any sample where the `tumor_grade` field matches the string
+    /// provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub tumor_grade: Option<String>,
+
     /// Matches any sample where the `specimen_molecular_analyte_type` field matches the string
     /// provided.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/ccdi-server/src/routes/sample.rs
+++ b/crates/ccdi-server/src/routes/sample.rs
@@ -484,6 +484,18 @@ fn parse_field(field: &str, sample: &Sample) -> Option<Option<Value>> {
             ),
             None => Some(None),
         },
+        "tumor_grade" => match sample.metadata() {
+            Some(metadata) => Some(
+                metadata
+                    .tumor_grade()
+                    .as_ref()
+                    // SAFETY: all metadata fields are able to be represented as
+                    // [`serde_json::Value`]s.
+                    .map(|tumor_grade| serde_json::to_value(tumor_grade.value()).unwrap())
+                    .or(Some(Value::Null)),
+            ),
+            None => Some(None),
+        },
         "specimen_molecular_analyte_type" => match sample.metadata() {
             Some(metadata) => Some(
                 metadata

--- a/docs/.vitepress/src/api/core.ts
+++ b/docs/.vitepress/src/api/core.ts
@@ -552,6 +552,27 @@ export enum CdeV2SamplePreservationMethod {
 }
 
 /**
+ * **`caDSR CDE 11325685 v2.00`**
+ *
+ * This metadata element is defined by the caDSR as "A text term to express the degree
+ * of abnormality of cancer cells as a measure of differentiation and aggressiveness.".
+ *
+ * Link:
+ * <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11325685%20and%20ver_nr=2>
+ */
+export enum CdeV2SampleTumorGrade {
+  G1LowGrade = "G1 Low Grade",
+  G2IntermediateGrade = "G2 Intermediate Grade",
+  G3HighGrade = "G3 High Grade",
+  G4Anaplastic = "G4 Anaplastic",
+  GBBorderline = "GB Borderline",
+  GXGrade = "GX Grade Cannot Be Assessed",
+  NotApplicable = "Not Applicable",
+  NotReported = "Not Reported",
+  Unknown = "Unknown",
+}
+
+/**
  * **`caDSR CDE 2192217 v2.00`**
  *
  * This metadata element is defined by the caDSR as "The text for reporting
@@ -972,6 +993,29 @@ export interface FieldUnownedSamplePreservationMethod {
    * <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=8028962%20and%20ver_nr=2>
    */
   value: CdeV2SamplePreservationMethod;
+  /**
+   * The ancestors from which this field was derived.
+   *
+   * Ancestors should be provided as period (`.`) delimited paths
+   * from the `metadata` key in the subject response object.
+   */
+  ancestors?: string[];
+  details?: ModelsMetadataFieldDetails;
+  /** A free-text comment field. */
+  comment?: string;
+}
+
+export interface FieldUnownedSampleTumorGrade {
+  /**
+   * **`caDSR CDE 11325685 v2.00`**
+   *
+   * This metadata element is defined by the caDSR as "A text term to express the degree
+   * of abnormality of cancer cells as a measure of differentiation and aggressiveness.".
+   *
+   * Link:
+   * <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11325685%20and%20ver_nr=2>
+   */
+  value: CdeV2SampleTumorGrade;
   /**
    * The ancestors from which this field was derived.
    *
@@ -2141,6 +2185,7 @@ export type ModelsSampleMetadata = ModelsMetadataCommonMetadata & {
   age_at_collection: FieldUnownedSampleAgeAtCollection | null;
   library_strategy: FieldUnownedSampleLibraryStrategy | null;
   preservation_method: FieldUnownedSamplePreservationMethod | null;
+  tumor_grade: FieldUnownedSampleTumorGrade | null;
   /**
    * The alternate identifiers for the sample.
    *
@@ -3215,6 +3260,11 @@ export class Api<
          * provided.
          */
         preservation_method?: string;
+        /**
+         * Matches any sample where the `tumor_grade` field matches the string
+         * provided.
+         */
+        tumor_grade?: string;
         /**
          * Matches any sample where the `tissue_type` field matches the string
          * provided.

--- a/swagger.yml
+++ b/swagger.yml
@@ -395,6 +395,14 @@ paths:
         required: false
         schema:
           type: string
+      - name: tumor_grade
+        in: query
+        description: |-
+          Matches any sample where the `tumor_grade` field matches the string
+          provided.
+        required: false
+        schema:
+          type: string
       - name: specimen_molecular_analyte_type
         in: query
         description: |-
@@ -1626,6 +1634,27 @@ components:
       - OCT
       - Snap Frozen
       - Unknown
+    cde.v2.sample.TumorGrade:
+      type: string
+      description: |-
+        **`caDSR CDE 11325685 v2.00`**
+
+        This metadata element is defined by the caDSR as "A text term to express
+        the degree of abnormality of cancer cells as a measure of differentiation
+        and aggressiveness.".
+
+        Link:
+        <https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11325685%20and%20ver_nr=2>
+      enum:
+      - G1 Low Grade
+      - G2 Intermediate Grade
+      - G3 High Grade
+      - G4 Anaplastic
+      - GB Borderline
+      - GX Grade Cannot Be Assessed
+      - Not Applicable
+      - Not Reported
+      - Unknown
     cde.v2.subject.Ethnicity:
       type: string
       description: |-
@@ -2166,6 +2195,28 @@ components:
       properties:
         value:
           $ref: '#/components/schemas/cde.v1.sample.TumorClassification'
+        ancestors:
+          type: array
+          items:
+            type: string
+          description: |-
+            The ancestors from which this field was derived.
+
+            Ancestors should be provided as period (`.`) delimited paths
+            from the `metadata` key in the subject response object.
+        details:
+          allOf:
+          - $ref: '#/components/schemas/models.metadata.field.Details'
+        comment:
+          type: string
+          description: A free-text comment field.
+    field.unowned.sample.TumorGrade:
+      type: object
+      required:
+      - value
+      properties:
+        value:
+          $ref: '#/components/schemas/cde.v2.sample.TumorGrade'
         ancestors:
           type: array
           items:
@@ -3343,6 +3394,7 @@ components:
         - library_strategy
         - library_source_material
         - preservation_method
+        - tumor_grade
         - specimen_molecular_analyte_type
         - identifiers
         properties:
@@ -3393,6 +3445,10 @@ components:
           preservation_method:
             allOf:
             - $ref: '#/components/schemas/field.unowned.sample.PreservationMethod'
+            nullable: true
+          tumor_grade:
+            allOf:
+            - $ref: '#/components/schemas/field.unowned.sample.TumorGrade'
             nullable: true
           specimen_molecular_analyte_type:
             allOf:


### PR DESCRIPTION
This PR adds the `tumor_grade` field to the spec based on the [discussion](https://github.com/CBIIT/ccdi-federation-api/discussions/137).

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional
      Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added a line describing the change in the `CHANGELOG.md` under
      `[Unreleased]`.

If you are adding new metadata elements, please uncomment this section and
complete the checklist as well:

- [x] I have added my field definition to the appropriate
  `get_field_descriptions()` method. For example, if you add a field to
  subjects, you should include it in the `get_field_descriptions()` method at
  `crates/ccdi_models/src/metadata/field/description/harmonized/subject.rs`.
- [x] I have confirmed that my field shows up in the relevant
  `/metadata/fields/<entity>` endpoint. For example. if you add a field to
  subjects, it should show up in the fields listed in the output of the
  `/metadata/fields/subject` endpoint.
- [x] I have confirmed that my field filters correctly when filtered from the
  root endpoint (`/subject`, `/sample`, etc). For example, if you add the
  `anatomical_sites` field to the sample endpoint, make sure that visiting
  `http://localhost:8000/sample?anatomical_sites=foobar` works.
- [x] I have confirmed that my field shows up in the relevant wiki generation
  command. For example. if you add a field to subjects, it should show up in the
  `cargo run --release wiki subject` output.

I will need to update this wiki while merging this change.