### PR TITLE
feat: add experimental subject-diagnosis endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,23 @@ and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
 - added associated_diagnoses to the /subject endpoint
   ([#141](https://github.com/CBIIT/ccdi-federation-api/pull/141)).
 - added associated_diagnoses to the /subject/by/{}/count endpoint
   ([#150](https://github.com/CBIIT/ccdi-federation-api/pull/150).
-
-### Added
-
 - Adds Sample ID CDE description to the `name`
   ([discussion](https://github.com/CBIIT/ccdi-federation-api/discussions/136),
   [#148](https://github.com/CBIIT/ccdi-federation-api/pull/148)).
 - Adds Tumor Grade
   ([discussion](https://github.com/CBIIT/ccdi-federation-api/discussions/137),
   [#149](https://github.com/CBIIT/ccdi-federation-api/pull/149)).
-
-### Added
-
-- Adds an experimental `sample-diagnosis` endpoint with `search` filter to enable case-insensitive substring searching of diagnoses. 
+- Adds an experimental `sample-diagnosis` endpoint with `search` filter to enable case-insensitive substring searching of diagnoses.
 ([discussion](https://github.com/CBIIT/ccdi-federation-api/discussions/131), [#139](https://github.com/CBIIT/ccdi-federation-api/issues/139)).
+- Adds an experimental `subject-diagnosis` endpoint with `search` filter to enable case-insensitive substring searching of diagnoses associated with a subject.
+([discussion](https://github.com/CBIIT/ccdi-federation-api/discussions/131), [#152](https://github.com/CBIIT/ccdi-federation-api/issues/152)).
 
 ### Changed
 

--- a/crates/ccdi-models/src/subject/metadata.rs
+++ b/crates/ccdi-models/src/subject/metadata.rs
@@ -469,13 +469,22 @@ impl Metadata {
                 None,
                 None,
             )),
-
-            associated_diagnoses: Some(vec![field::unowned::subject::AssociatedDiagnoses::new(
-                AssociatedDiagnoses::from(String::from("Random Diagnosis")),
-                None,
-                None,
-                None,
-            )]),
+            // One to three diagnoses of the format Random Diagnosis X
+            associated_diagnoses: Some(
+                (0..rng.gen_range(1..4))
+                    .map(|_| {
+                        field::unowned::subject::AssociatedDiagnoses::new(
+                            AssociatedDiagnoses::from(format!(
+                                "Random Diagnosis {}",
+                                rng.sample(Alphanumeric).to_ascii_uppercase() as char,
+                            )),
+                            None,
+                            None,
+                            None,
+                        )
+                    })
+                    .collect(),
+            ),
 
             common: Default::default(),
             unharmonized: Default::default(),

--- a/crates/ccdi-openapi/src/api.rs
+++ b/crates/ccdi-openapi/src/api.rs
@@ -127,6 +127,7 @@ use utoipa::openapi;
 
         // Experimental.
         server::routes::sample_diagnosis::sample_diagnosis_index,
+        server::routes::subject_diagnosis::subject_diagnosis_index,
     ),
     components(schemas(
         // Harmonized common metadata elements.

--- a/crates/ccdi-server/src/filter.rs
+++ b/crates/ccdi-server/src/filter.rs
@@ -10,6 +10,7 @@ pub mod file;
 pub mod sample;
 pub mod sample_diagnosis;
 pub mod subject;
+pub mod subject_diagnosis;
 
 /// A trait that defines a method for filtering by metadata values.
 ///

--- a/crates/ccdi-server/src/filter/subject_diagnosis.rs
+++ b/crates/ccdi-server/src/filter/subject_diagnosis.rs
@@ -1,0 +1,127 @@
+//! Filter parameters for [`Subject`]s on the subject-diagnosis endpoint.
+
+use ccdi_models as models;
+
+use models::metadata::common::deposition::Accession;
+use models::Subject;
+
+use crate::filter::FilterMetadataField;
+use crate::params::filter::SubjectDiagnosis as FilterSubjectDiagnosisParams;
+
+impl FilterMetadataField<Subject, FilterSubjectDiagnosisParams> for Vec<Subject> {
+    fn filter_metadata_field(
+        self,
+        field: String,
+        params: &FilterSubjectDiagnosisParams,
+    ) -> Vec<Subject> {
+        let parameter = match field.as_str() {
+            "sex" => params.sex.as_ref(),
+            "race" => params.race.as_ref(),
+            "ethnicity" => params.ethnicity.as_ref(),
+            "identifiers" => params.identifiers.as_ref(),
+            "vital_status" => params.vital_status.as_ref(),
+            "age_at_vital_status" => params.age_at_vital_status.as_ref(),
+            "depositions" => params.depositions.as_ref(),
+            "search" => params.search.as_ref(),
+            _ => unreachable!("unhandled subject metadata field: {field}"),
+        };
+
+        let query = match parameter {
+            Some(query) => query,
+            // If the parameter has no value, just return the original list of
+            // subjects, as the user does not want to filter based on that.
+            None => return self,
+        };
+
+        self.into_iter()
+            .filter(|subject| {
+                if field.as_str() == "search" {
+                    if let Some(metadata) = subject.metadata() {
+                        if let Some(associated_diagnoses) = metadata.associated_diagnoses() {
+                            // Only return the entry if the query is a substring
+                            // of at least one of the associated_diagnoses, ignoring case.
+                            // Matching on to_lowercase is an approximation and will not cover
+                            // all unicode characters.
+                            let query_lower = query.to_string().to_lowercase();
+
+                            let diagnoses_lower = associated_diagnoses
+                                .iter()
+                                .cloned()
+                                .map(|r| r.value().to_string().to_lowercase())
+                                .collect::<Vec<String>>();
+
+                            return diagnoses_lower
+                                .iter()
+                                .any(|diagnosis_lower| diagnosis_lower.contains(&query_lower));
+                        }
+                        // If the metadata doesn't have associated_diagnoses, the entry
+                        // should not be included.
+                        return false;
+                    }
+                    // If no metadata is included, this entry should not be
+                    // included.
+                    false
+                } else {
+                    // All other "non-search" fields require an exact case-sensitive match.
+                    let values: Option<Vec<String>> =
+                        match field.as_str() {
+                            "sex" => subject
+                                .metadata()
+                                .and_then(|metadata| metadata.sex())
+                                .map(|sex| vec![sex.to_string()]),
+                            "race" => subject.metadata().and_then(|metadata| metadata.race()).map(
+                                |race| {
+                                    race.iter()
+                                        .cloned()
+                                        .map(|r| r.to_string())
+                                        .collect::<Vec<String>>()
+                                },
+                            ),
+                            "ethnicity" => subject
+                                .metadata()
+                                .and_then(|metadata| metadata.ethnicity())
+                                .map(|ethnicity| vec![ethnicity.to_string()]),
+                            "identifiers" => subject
+                                .metadata()
+                                .and_then(|metadata| metadata.identifiers())
+                                .map(|identifiers| {
+                                    identifiers
+                                        .iter()
+                                        .cloned()
+                                        .map(|r| r.to_string())
+                                        .collect::<Vec<String>>()
+                                }),
+                            "vital_status" => subject
+                                .metadata()
+                                .and_then(|metadata| metadata.vital_status())
+                                .map(|vital_status| vec![vital_status.to_string()]),
+                            "age_at_vital_status" => subject
+                                .metadata()
+                                .and_then(|metadata| metadata.age_at_vital_status())
+                                .map(|age_at_vital_status| vec![age_at_vital_status.to_string()]),
+                            "depositions" => subject
+                                .metadata()
+                                .and_then(|metadata| metadata.common().depositions())
+                                .map(|deposition| {
+                                    deposition
+                                        .iter()
+                                        .cloned()
+                                        .map(|accession| match accession {
+                                            Accession::dbGaP(accession) => accession.to_string(),
+                                        })
+                                        .collect::<Vec<String>>()
+                                }),
+                            _ => unreachable!("unhandled subject metadata field: {field}"),
+                        };
+
+                    match values {
+                        Some(values) => values.into_iter().any(|s| s.eq(query)),
+                        // Subjects with no values for this field are automatically
+                        // filtered as described in the rules for filtering.
+                        None => false,
+                    }
+                }
+            })
+            .collect::<Vec<_>>()
+    }
+}

--- a/crates/ccdi-server/src/params/filter.rs
+++ b/crates/ccdi-server/src/params/filter.rs
@@ -67,6 +67,77 @@ pub struct Subject {
     pub depositions: Option<String>,
 }
 
+/// Parameters for filtering experimental subject-diagnosis endpoint.
+///
+/// None of the parameters are required, but they may be provided as a
+/// [`String`]. When a parameter is provided, the endpoint will filter the
+/// results to only include [`Subject`]s where the value for the key exactly
+/// matches the value provided for the parameter (i.e., matching is done by
+/// looking for the provided parameter as a substring). Matches are
+/// case-sensitive.
+#[derive(Debug, Default, Deserialize, IntoParams, Introspect, Serialize)]
+#[into_params(parameter_in = Query)]
+pub struct SubjectDiagnosis {
+    /// Matches any subject where any member of the `associated_diagnoses` field contains the
+    /// string provided, ignoring case.
+    ///
+    /// **Note:** a logical OR (`||`) is performed across the values when
+    /// determining whether the subject should be included in the results.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub search: Option<String>,
+
+    /// Matches any subject where the `sex` field matches the string provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub sex: Option<String>,
+
+    /// Matches any subject where any member of the `race` field matches the
+    /// string provided.
+    ///
+    /// **Note:** a logical OR (`||`) is performed across the values when
+    /// determining whether the subject should be included in the results.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub race: Option<String>,
+
+    /// Matches any subject where the `ethnicity` field matches the string
+    /// provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub ethnicity: Option<String>,
+
+    /// Matches any subject where any member of the `identifiers` field matches
+    /// the string provided.
+    ///
+    /// **Note:** a logical OR (`||`) is performed across the values when
+    /// determining whether the subject should be included in the results.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub identifiers: Option<String>,
+
+    /// Matches any subject where the `vital_status` field matches the string
+    /// provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub vital_status: Option<String>,
+
+    /// Matches any subject where the `age_at_vital_status` field matches the
+    /// string provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub age_at_vital_status: Option<String>,
+
+    /// Matches any subject where any member of the `depositions` fields match
+    /// the string provided.
+    ///
+    /// **Note:** a logical OR (`||`) is performed across the values when
+    /// determining whether the subject should be included in the results.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[param(required = false, nullable = false)]
+    pub depositions: Option<String>,
+}
+
 /// Parameters for filtering samples.
 ///
 /// None of the parameters are required, but they may be provided as a

--- a/crates/ccdi-server/src/routes.rs
+++ b/crates/ccdi-server/src/routes.rs
@@ -8,6 +8,7 @@ pub mod organization;
 pub mod sample;
 pub mod sample_diagnosis;
 pub mod subject;
+pub mod subject_diagnosis;
 
 /// A result for a group by operation.
 #[derive(Debug)]

--- a/crates/ccdi-server/src/routes/subject_diagnosis.rs
+++ b/crates/ccdi-server/src/routes/subject_diagnosis.rs
@@ -1,0 +1,192 @@
+//! Routes related to the experimental subject-diagnosis endpoint.
+
+use actix_web::get;
+use actix_web::web::Data;
+use actix_web::web::Query;
+use actix_web::web::ServiceConfig;
+use actix_web::Responder;
+
+use ccdi_models as models;
+
+use models::Subject;
+
+use crate::filter::filter;
+use crate::paginate;
+use crate::params::filter::SubjectDiagnosis as FilterSubjectDiagnosisParams;
+use crate::params::PaginationParams;
+use crate::responses::error;
+use crate::responses::Errors;
+use crate::responses::Subjects;
+
+use crate::routes::subject::Store;
+
+/// Configures the [`ServiceConfig`] with the subject paths.
+pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
+    |config: &mut ServiceConfig| {
+        config.app_data(store).service(subject_diagnosis_index);
+    }
+}
+
+/// Experimental: Filter the subjects known by this server by free-text diagnosis search.
+///
+/// ### Diagnosis Filtering
+///
+/// This endpoint supports the experimental `search` parameter.
+/// For this parameter, the subject is included in the results if the value of its
+/// its `associated_diagnoses` field has at least one diagnosis which _contains_ the query string.
+/// Matches are case-insensitive.
+///
+/// ### Pagination
+///
+/// This endpoint is paginated. Users may override the default pagination
+/// parameters by providing one or more of the pagination-related query
+/// parameters below.
+///
+/// ### Additional Filtering
+///
+/// All harmonized (top-level) and unharmonized (nested under the
+/// `metadata.unharmonized` key) metadata fields are filterable. To achieve
+/// this, you can provide the field name as a [`String`]. Filtering follows the
+/// following rules:
+///
+/// * For single-value metadata field, the subject is included in the results if
+///   its value _exactly_ matches the query string. Matches are case-sensitive.
+/// * For multiple-value metadata fields, the subject is included in the results
+///   if any of its values for the field _exactly_ match the query string (a
+///   logical OR [`||`]). Matches are case-sensitive.
+/// * When the metadata field is `null` (in the case of singular or
+///   multiple-valued metadata fields) or empty, the subject is not included.
+/// * When multiple fields are provided as filters, a logical AND (`&&`) strings
+///   together the predicates. In other words, all filters must match for a
+///   subject to be returned. Note that this means that servers do not natively
+///   support logical OR (`||`) across multiple fields: that must be done by
+///   calling this endpoint with each of your desired queries and performing a
+///   set union of those subjects out of band.
+///
+/// ### Ordering
+///
+/// This endpoint has default ordering requirements—those details are documented
+/// in the `responses::Subjects` schema.
+#[utoipa::path(
+    get,
+    path = "/subject-diagnosis",
+    tag = "Experimental",
+    params(
+        FilterSubjectDiagnosisParams,
+        (
+            "metadata.unharmonized.<field>" = Option<String>,
+            Query,
+            nullable = false,
+            description = "All unharmonized fields should be filterable in the \
+            same manner as harmonized fields:\n\n\
+            * Filtering on a singular field should include the `Subject` in \
+            the results if the query exactly matches the value of that field \
+            for the `Subject` (case-sensitive).\n\
+            * Filtering on field with multiple values should include the \
+            `Subject` in the results if the query exactly matches any of the \
+            values of the field for that `Subject` (case-sensitive).\n\
+            * Unlike harmonized fields, unharmonized fields must be prefixed \
+            with `metadata.unharmonized`.\n\n\
+            **Note:** this query parameter is intended to be symbolic of any \
+            unharmonized field. Because of limitations within Swagger UI, it \
+            will show up as a query parameter that can be optionally be \
+            submitted as part of a request within Swagger UI. Please keep in \
+            mind that the literal query parameter \
+            `?metadata.unharmonized.<field>=value` is not supported, so \
+            attempting to use it within Swagger UI will not work!"
+        ),
+        PaginationParams,
+    ),
+    responses(
+        (
+            status = 200,
+            description = "Successful operation.",
+            body = responses::Subjects,
+            headers(
+                (
+                    "link" = String,
+                    description = "Links to URLs that may be of interest \
+                    when paging through paginated responses. This header \
+                    contains two or more links of interest. The format of the \
+                    field is as follows: \
+                    \n\
+                    \n`Link: <URL>; rel=\"REL\"` \
+                    \n\
+                    ### Relationships\n\n\
+                    In the format above, `URL` represents a valid URL for \
+                    the link of interest and `REL` is one of four values: \n\
+                    - `first` (_Required_). A link to the first page in the \
+                    results (can be the same as `last` if there is only one \
+                    page).\n\
+                    - `last` (_Required_). A link to the first page in the \
+                    results (can be the same as `first` if there is only one \
+                    page).\n\
+                    - `next` (_Optional_). A link to the next page (if it \
+                    exists).\n\
+                    - `prev` (_Optional_). A link to the previous page (if it \
+                    exists).\n\n\
+                    ### Requirements\n\n\
+                    - This header _must_ provide links for at least the `first` \
+                    and `last` rels.\n \
+                    - The `prev` and `next` links must exist only (a) when there \
+                    are multiple pages in the result page set and (b) when the \
+                    current page is not the first or last page, respectively.\n\
+                    - This list of links is unordered.\n\n \
+                    ### Notes\n\n\
+                    - HTTP 1.1 and HTTP 2.0 dictate that response \
+                    headers are case insensitive. Though not required, we \
+                    recommend an all lowercase name of `link` for this \
+                    response header."
+                )
+            )
+        ),
+        (
+            status = 404,
+            description = "Not found.\nServers that cannot provide line-level \
+            data should use this response rather than Forbidden (403), as \
+            there is no level of authorization that would allow one to access \
+            the information included in the API.",
+            body = responses::Errors,
+            example = json!(
+                Errors::from(
+                    error::Kind::unshareable_data(
+                        String::from("subjects"),
+                        String::from(
+                            "Our agreement with data providers prohibits us from sharing \
+                            line-level data."
+                        ),
+                    )
+                )
+            )
+        ),
+        (
+            status = 422,
+            description = "Invalid query or path parameters.",
+            body = responses::Errors,
+            example = json!(Errors::from(error::Kind::invalid_parameters(
+                Some(vec![String::from("page"), String::from("per_page")]),
+                String::from("unable to calculate offset")
+            )))
+        ),
+    )
+)]
+#[get("/subject-diagnosis")]
+pub async fn subject_diagnosis_index(
+    filter_params: Query<FilterSubjectDiagnosisParams>,
+    pagination_params: Query<PaginationParams>,
+    subjects: Data<Store>,
+) -> impl Responder {
+    let mut subjects = subjects.subjects.lock().unwrap().clone();
+
+    // See the note in the documentation for this endpoint: the results must be
+    // sorted by identifier by default.
+    subjects.sort();
+
+    let subjects = filter::<Subject, FilterSubjectDiagnosisParams>(subjects, filter_params.0);
+
+    paginate::response::<Subject, Subjects>(
+        pagination_params.0,
+        subjects,
+        "http://localhost:8000/subject",
+    )
+}

--- a/crates/ccdi-spec/src/main.rs
+++ b/crates/ccdi-spec/src/main.rs
@@ -42,6 +42,7 @@ use server::routes::namespace;
 use server::routes::sample;
 use server::routes::sample_diagnosis;
 use server::routes::subject;
+use server::routes::subject_diagnosis;
 
 mod utils;
 
@@ -341,6 +342,7 @@ fn inner() -> Result<(), Box<dyn std::error::Error>> {
                         .configure(organization::configure())
                         .configure(info::configure())
                         .configure(sample_diagnosis::configure(samples.clone()))
+                        .configure(subject_diagnosis::configure(subjects.clone()))
                         .service(
                             SwaggerUi::new("/swagger-ui/{_:.*}")
                                 .url("/api-docs/openapi.json", Api::openapi()),

--- a/swagger.yml
+++ b/swagger.yml
@@ -1302,6 +1302,205 @@ paths:
                   - per_page
                   reason: Unable to calculate offset.
                   message: 'Invalid value for parameters ''page'' and ''per_page'': unable to calculate offset.'
+  /subject-diagnosis:
+    get:
+      tags:
+      - Experimental
+      summary: 'Experimental: Filter the subjects known by this server by free-text diagnosis search.'
+      description: |-
+        Experimental: Filter the subjects known by this server by free-text diagnosis search.
+
+        ### Diagnosis Filtering
+
+        This endpoint supports the experimental `search` parameter.
+        For this parameter, the subject is included in the results if the value of its
+        its `associated_diagnoses` field has at least one diagnosis which _contains_ the query string.
+        Matches are case-insensitive.
+
+        ### Pagination
+
+        This endpoint is paginated. Users may override the default pagination
+        parameters by providing one or more of the pagination-related query
+        parameters below.
+
+        ### Additional Filtering
+
+        All harmonized (top-level) and unharmonized (nested under the
+        `metadata.unharmonized` key) metadata fields are filterable. To achieve
+        this, you can provide the field name as a [`String`]. Filtering follows the
+        following rules:
+
+        * For single-value metadata field, the subject is included in the results if
+        its value _exactly_ matches the query string. Matches are case-sensitive.
+        * For multiple-value metadata fields, the subject is included in the results
+        if any of its values for the field _exactly_ match the query string (a
+        logical OR [`||`]). Matches are case-sensitive.
+        * When the metadata field is `null` (in the case of singular or
+        multiple-valued metadata fields) or empty, the subject is not included.
+        * When multiple fields are provided as filters, a logical AND (`&&`) strings
+        together the predicates. In other words, all filters must match for a
+        subject to be returned. Note that this means that servers do not natively
+        support logical OR (`||`) across multiple fields: that must be done by
+        calling this endpoint with each of your desired queries and performing a
+        set union of those subjects out of band.
+
+        ### Ordering
+
+        This endpoint has default ordering requirements—those details are documented
+        in the `responses::Subjects` schema.
+      operationId: subject_diagnosis_index
+      parameters:
+      - name: search
+        in: query
+        description: |-
+          Matches any subject where any member of the `associated_diagnoses` field contains the
+          string provided, ignoring case.
+
+          **Note:** a logical OR (`||`) is performed across the values when
+          determining whether the subject should be included in the results.
+        required: false
+        schema:
+          type: string
+      - name: sex
+        in: query
+        description: Matches any subject where the `sex` field matches the string provided.
+        required: false
+        schema:
+          type: string
+      - name: race
+        in: query
+        description: |-
+          Matches any subject where any member of the `race` field matches the
+          string provided.
+
+          **Note:** a logical OR (`||`) is performed across the values when
+          determining whether the subject should be included in the results.
+        required: false
+        schema:
+          type: string
+      - name: ethnicity
+        in: query
+        description: |-
+          Matches any subject where the `ethnicity` field matches the string
+          provided.
+        required: false
+        schema:
+          type: string
+      - name: identifiers
+        in: query
+        description: |-
+          Matches any subject where any member of the `identifiers` field matches
+          the string provided.
+
+          **Note:** a logical OR (`||`) is performed across the values when
+          determining whether the subject should be included in the results.
+        required: false
+        schema:
+          type: string
+      - name: vital_status
+        in: query
+        description: |-
+          Matches any subject where the `vital_status` field matches the string
+          provided.
+        required: false
+        schema:
+          type: string
+      - name: age_at_vital_status
+        in: query
+        description: |-
+          Matches any subject where the `age_at_vital_status` field matches the
+          string provided.
+        required: false
+        schema:
+          type: string
+      - name: depositions
+        in: query
+        description: |-
+          Matches any subject where any member of the `depositions` fields match
+          the string provided.
+
+          **Note:** a logical OR (`||`) is performed across the values when
+          determining whether the subject should be included in the results.
+        required: false
+        schema:
+          type: string
+      - name: metadata.unharmonized.<field>
+        in: query
+        description: |-
+          All unharmonized fields should be filterable in the same manner as harmonized fields:
+
+          * Filtering on a singular field should include the `Subject` in the results if the query exactly matches the value of that field for the `Subject` (case-sensitive).
+          * Filtering on field with multiple values should include the `Subject` in the results if the query exactly matches any of the values of the field for that `Subject` (case-sensitive).
+          * Unlike harmonized fields, unharmonized fields must be prefixed with `metadata.unharmonized`.
+
+          **Note:** this query parameter is intended to be symbolic of any unharmonized field. Because of limitations within Swagger UI, it will show up as a query parameter that can be optionally be submitted as part of a request within Swagger UI. Please keep in mind that the literal query parameter `?metadata.unharmonized.<field>=value` is not supported, so attempting to use it within Swagger UI will not work!
+        required: false
+        schema:
+          type: string
+      - name: page
+        in: query
+        description: |-
+          The page to retrieve.
+
+          This is a 1-based index of a page within a page set. The value of `page`
+          **must** default to `1` when this parameter is not provided.
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+      - name: per_page
+        in: query
+        description: |-
+          The number of results per page.
+
+          Each server can select its own default value for `per_page` when this
+          parameter is not provided. That said, the convention within the
+          community is to use `100` as a default value if any value is equally
+          reasonable.
+        required: false
+        schema:
+          type: integer
+          minimum: 0
+      responses:
+        '200':
+          description: Successful operation.
+          headers:
+            link:
+              schema:
+                type: string
+              description: "Links to URLs that may be of interest when paging through paginated responses. This header contains two or more links of interest. The format of the field is as follows: \n\n`Link: <URL>; rel=\"REL\"` \n### Relationships\n\nIn the format above, `URL` represents a valid URL for the link of interest and `REL` is one of four values: \n- `first` (_Required_). A link to the first page in the results (can be the same as `last` if there is only one page).\n- `last` (_Required_). A link to the first page in the results (can be the same as `first` if there is only one page).\n- `next` (_Optional_). A link to the next page (if it exists).\n- `prev` (_Optional_). A link to the previous page (if it exists).\n\n### Requirements\n\n- This header _must_ provide links for at least the `first` and `last` rels.\n - The `prev` and `next` links must exist only (a) when there are multiple pages in the result page set and (b) when the current page is not the first or last page, respectively.\n- This list of links is unordered.\n\n ### Notes\n\n- HTTP 1.1 and HTTP 2.0 dictate that response headers are case insensitive. Though not required, we recommend an all lowercase name of `link` for this response header."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responses.Subjects'
+        '404':
+          description: |-
+            Not found.
+            Servers that cannot provide line-level data should use this response rather than Forbidden (403), as there is no level of authorization that would allow one to access the information included in the API.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responses.Errors'
+              example:
+                errors:
+                - kind: UnshareableData
+                  entity: Subjects
+                  reason: Our agreement with data providers prohibits us from sharing line-level data.
+                  message: 'Unable to share data for subjects: our agreement with data providers prohibits us from sharing line-level data.'
+        '422':
+          description: Invalid query or path parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/responses.Errors'
+              example:
+                errors:
+                - kind: InvalidParameters
+                  parameters:
+                  - page
+                  - per_page
+                  reason: Unable to calculate offset.
+                  message: 'Invalid value for parameters ''page'' and ''per_page'': unable to calculate offset.'
 components:
   schemas:
     cde.v1.deposition.DbgapPhsAccession:


### PR DESCRIPTION
Discussion: https://github.com/CBIIT/ccdi-federation-api/discussions/131 **Improved disease querying**
Project:
https://github.com/orgs/CBIIT/projects/19/views/1?pane=issue&itemId=102925260

**PR Close Date:** Not yet determined

**Main feature**
Adds `subject-diagnosis` endpoint with a `search` parameter. This parameter performs case-insensitive string subset searching on the `associated_diagnoses` field. 
Examples:
[http://localhost:8000/subject-diagnosis?search=Random Diagnosis](http://localhost:8000/subject-diagnosis?search=Random%20Diagnosis) : Returns all subject with at least one associated diagnosis.
http://localhost:8000/subject-diagnosis?search=X : Returns all subjects with associated diagnoses that include `Random Diagnosis X`
[http://localhost:8000/subject-diagnosis?search=SIS z](http://localhost:8000/subject-diagnosis?search=SIS%20z) Returns all subjects with associated diagnoses that include `Random Diagnosis Z`

Other `subject` parameters are also usable with `subject-diagnosis`. 
Example: http://localhost:8000/subject-diagnosis?vital_status=Unspecified&per_page=2

**Additional Changes**
Randomizes the `associated_diagnoses` of the subject similar to sample's `diagnosis`, so that the `search` queries can return meaningful results. 

**Known Caveats**
- the `search` parameter is not limited to the diagnosis character set described in #131 and will allow searches on all sorts of characters rather than returning an error. Example: [http://localhost:8000/subject-diagnosis?search=/Example🙂%^](http://localhost:8000/subject-diagnosis?search=/Example%F0%9F%99%82%^)
 
Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [X] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional
      Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate). *(Not applicable for this change)*
- [x] You have added a line describing the change in the `CHANGELOG.md` under
      `[Unreleased]`.

