### PR TITLE
feat: add ecDNA to servers list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ([discussion](https://github.com/CBIIT/ccdi-federation-api/discussions/131), [#139](https://github.com/CBIIT/ccdi-federation-api/issues/139)).
 - Adds an experimental `subject-diagnosis` endpoint with `search` filter to enable case-insensitive substring searching of diagnoses associated with a subject.
 ([discussion](https://github.com/CBIIT/ccdi-federation-api/discussions/131), [#152](https://github.com/CBIIT/ccdi-federation-api/issues/152)).
+- Adds the ecDNA CCDI API Server to the list of available implementations
+  ([#155](https://github.com/CBIIT/ccdi-federation-api/pull/155)).
 
 ### Changed
 

--- a/crates/ccdi-openapi/src/api.rs
+++ b/crates/ccdi-openapi/src/api.rs
@@ -55,6 +55,11 @@ use utoipa::openapi;
             url = "https://ccdi.kidsfirstdrc.org/api/v1",
             description = "KidsFirst CCDI API server"
         ),
+        (
+            url = "https://ccdi-ecdna.org/ccdi-federation/api/v1",
+            description = "Childhood Cancer Catalog of ecDNA CCDI API server"
+
+        ),
     ),
     tags(
         (

--- a/swagger.yml
+++ b/swagger.yml
@@ -28,6 +28,8 @@ servers:
   description: UCSC Treehouse CCDI API server
 - url: https://ccdi.kidsfirstdrc.org/api/v1
   description: KidsFirst CCDI API server
+- url: https://ccdi-ecdna.org/ccdi-federation/api/v1
+  description: Childhood Cancer Catalog of ecDNA CCDI API server
 paths:
   /subject:
     get:


### PR DESCRIPTION
**PR Close Date:** May 26, 2025

Adds the [Childhood Cancer Catalog of Circular Extrachromosomal DNA (ecDNA)](https://ccdi-ecdna.org/) API implementation to the list of servers available via the Swagger UI.
This does not retroactively add them to the [Sept 2024 blog post](https://cbiit.github.io/ccdi-federation-api/blog/09-25-2024-introducing-the-federation-api.html) as they were not avaialble at that time.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [X] You have added the relevant groups/individuals to the reviewers.
- [X] Your commit messages conform to the [Conventional
      Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] ~~You have updated the README or other documentation to account for these
      changes (when appropriate).~~ N/A
- [x] You have added a line describing the change in the `CHANGELOG.md` under
      `[Unreleased]`.