### PR TITLE
fix: update URL for swagger spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Updates link to the Swagger UI document.
+  ([#156](https://github.com/CBIIT/ccdi-federation-api/pull/156)).
+
 ## [v1.2.0] — 05-27-2025
 
 ### Added

--- a/crates/ccdi-openapi/src/api.rs
+++ b/crates/ccdi-openapi/src/api.rs
@@ -25,7 +25,7 @@ use utoipa::openapi;
   Federation node.
 * Additionally, you can view the Swagger specification in a more traditional
   theme by visiting
-  [this link](https://editor.swagger.io/?url=https://cbiit.github.io/ccdi-federation-api/swagger.yml).
+  [this link](https://cbiit.github.io/ccdi-federation-api/specification.html).
 * To access CCDI Data Federation Resource, please visit
   [this link](https://cbiit.github.io/ccdi-federation-api-aggregation/).",
         contact(

--- a/swagger.yml
+++ b/swagger.yml
@@ -12,7 +12,7 @@ info:
       Federation node.
     * Additionally, you can view the Swagger specification in a more traditional
       theme by visiting
-      [this link](https://editor.swagger.io/?url=https://cbiit.github.io/ccdi-federation-api/swagger.yml).
+      [this link](https://cbiit.github.io/ccdi-federation-api/specification.html).
     * To access CCDI Data Federation Resource, please visit
       [this link](https://cbiit.github.io/ccdi-federation-api-aggregation/).
   contact:


### PR DESCRIPTION
**PR Close Date:** June 6

The [swagger.yml document](https://github.com/CBIIT/ccdi-federation-api/blob/9cadcc5e7342515ba34abc8191b3f20ea068d62a/swagger.yml#L15) contains [a URL](https://editor.swagger.io/?url=https://cbiit.github.io/ccdi-federation-api/swagger.yml) ostensibly leading to a nicely formatted version; but it no longer works.

This updates the URL to https://cbiit.github.io/ccdi-federation-api/specification.html instead as suggested by @asafieva.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional
      Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [ ] N/A ~~You have updated the README or other documentation to account for these
      changes (when appropriate).~~
- [X] You have added a line describing the change in the `CHANGELOG.md` under
      `[Unreleased]`.
