### PR TITLE
docs: add a sentence stating that experimental endpoints don't break backwards compatibility

### DIFF
--- a/crates/ccdi-server/src/routes/sample_diagnosis.rs
+++ b/crates/ccdi-server/src/routes/sample_diagnosis.rs
@@ -69,6 +69,9 @@ pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
 ///
 /// This endpoint has default ordering requirements—those details are documented
 /// in the `responses::Samples` schema.
+///
+/// Note: This API is experimental and is subject to change without being considered
+/// as a breaking change.
 #[utoipa::path(
     get,
     path = "/sample-diagnosis",

--- a/crates/ccdi-server/src/routes/subject_diagnosis.rs
+++ b/crates/ccdi-server/src/routes/subject_diagnosis.rs
@@ -67,6 +67,9 @@ pub fn configure(store: Data<Store>) -> impl FnOnce(&mut ServiceConfig) {
 ///
 /// This endpoint has default ordering requirements—those details are documented
 /// in the `responses::Subjects` schema.
+///
+/// Note: This API is experimental and is subject to change without being considered
+/// as a breaking change.
 #[utoipa::path(
     get,
     path = "/subject-diagnosis",

--- a/swagger.yml
+++ b/swagger.yml
@@ -1099,6 +1099,9 @@ paths:
 
         This endpoint has default ordering requirements—those details are documented
         in the `responses::Samples` schema.
+
+        Note: This API is experimental and is subject to change without being considered
+        as a breaking change.
       operationId: sample_diagnosis_index
       parameters:
       - name: search
@@ -1350,6 +1353,9 @@ paths:
 
         This endpoint has default ordering requirements—those details are documented
         in the `responses::Subjects` schema.
+
+        Note: This API is experimental and is subject to change without being considered
+        as a breaking change.
       operationId: subject_diagnosis_index
       parameters:
       - name: search


### PR DESCRIPTION
This PR just adds a sentence about changes to experimental endpoints not breaking backwards compatibility based on feedback from Clay.

I just put a sentence in, but am open to any rephrasing of the sentence.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added the relevant groups/individuals to the reviewers.
- [x] Your commit messages conform to the [Conventional
      Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added a line describing the change in the `CHANGELOG.md` under
      `[Unreleased]`.